### PR TITLE
fix versions:set when used with an alternate POM

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -370,7 +370,7 @@ public class SetMojo
 
         if ( moduleDir.isDirectory() )
         {
-            moduleProjectFile = new File( moduleDir, "pom.xml" );
+            moduleProjectFile = project.getFile();
         }
         else
         {


### PR DESCRIPTION
When using an alternate pom with `mvn -f alternate-pom.xml versions:set -DnewVersion=0.0.1`, submodule versions are updated, but not the parent pom version.

This fix works with an alternate pom and with a classic `pom.xml`