### PR TITLE
Updating properties should support LATEST and RELEASE values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,12 @@
       <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/it-display-property-updates-002/invoker.properties
+++ b/src/it/it-display-property-updates-002/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DautoLinkItems=true ${project.groupId}:${project.artifactId}:${project.version}:display-property-updates

--- a/src/it/it-display-property-updates-002/pom.xml
+++ b/src/it/it-display-property-updates-002/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-004</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties with one property auto-linked and range limited</name>
+
+  <properties>
+    <api>LATEST</api>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>${api}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/it-display-property-updates-002/verify.bsh
+++ b/src/it/it-display-property-updates-002/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "build.log" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "LATEST -> 3.0" ) < 0 )
+    {
+        System.err.println( "Did not suggest updating ${api} to version 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-display-property-updates-003/invoker.properties
+++ b/src/it/it-display-property-updates-003/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DautoLinkItems=true ${project.groupId}:${project.artifactId}:${project.version}:display-property-updates -DresolveLatest=false

--- a/src/it/it-display-property-updates-003/pom.xml
+++ b/src/it/it-display-property-updates-003/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-004</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties with one property auto-linked and range limited</name>
+
+  <properties>
+    <api>LATEST</api>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>${api}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/it-display-property-updates-003/verify.bsh
+++ b/src/it/it-display-property-updates-003/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "build.log" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "All version properties are referencing the newest version available" ) < 0 )
+    {
+        System.err.println( "Should not have suggested updating ${api} from LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-update-properties-015/invoker.properties
+++ b/src/it/it-update-properties-015/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:update-properties

--- a/src/it/it-update-properties-015/pom.xml
+++ b/src/it/it-update-properties-015/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties with one property only</name>
+
+  <properties>
+    <api>LATEST</api>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>${api}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/it-update-properties-015/verify.bsh
+++ b/src/it/it-update-properties-015/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<api>3.0</api>" ) < 0 )
+    {
+        System.err.println( "Version not updated to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-update-properties-016/invoker.properties
+++ b/src/it/it-update-properties-016/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:update-properties -DresolveLatest=false

--- a/src/it/it-update-properties-016/pom.xml
+++ b/src/it/it-update-properties-016/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties with one property only</name>
+
+  <properties>
+    <api>LATEST</api>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>${api}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/it-update-properties-016/verify.bsh
+++ b/src/it/it-update-properties-016/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<api>LATEST</api>" ) < 0 )
+    {
+        System.err.println( "Version LATEST should not have been resolved to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-update-property-003/invoker.properties
+++ b/src/it/it-update-property-003/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:update-property -Dproperty=api -DnewVersion=LATEST -DresolveLatest=false

--- a/src/it/it-update-property-003/pom.xml
+++ b/src/it/it-update-property-003/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties via autolink with one property only</name>
+
+  <properties>
+    <api>1.0</api>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <version>${api}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-update-property-003/verify.bsh
+++ b/src/it/it-update-property-003/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<api>LATEST</api>" ) < 0 )
+    {
+        System.err.println( "Version not updated to LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-update-property-004/invoker.properties
+++ b/src/it/it-update-property-004/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:update-property -Dproperty=api -DresolveLatest=false

--- a/src/it/it-update-property-004/pom.xml
+++ b/src/it/it-update-property-004/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties via autolink with one property only</name>
+
+  <properties>
+    <api>LATEST</api>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <version>${api}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+</project>

--- a/src/it/it-update-property-004/verify.bsh
+++ b/src/it/it-update-property-004/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<api>LATEST</api>" ) < 0 )
+    {
+        System.err.println( "Should not have resolved LATEST to a real version" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-update-property-005/invoker.properties
+++ b/src/it/it-update-property-005/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:update-property -Dproperty=api

--- a/src/it/it-update-property-005/pom.xml
+++ b/src/it/it-update-property-005/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties via autolink with one property only</name>
+
+  <properties>
+    <api>1.0</api>
+  </properties>
+
+<build>
+  <plugins>
+    <plugin>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>@project.version@</version>
+      <configuration>
+        <properties>
+          <property>
+            <name>api</name>
+            <dependencies>
+              <dependency>
+                <groupId>localhost</groupId>
+                <artifactId>dummy-api</artifactId>
+              </dependency>
+            </dependencies>
+          </property>
+        </properties>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+  
+</project>

--- a/src/it/it-update-property-005/verify.bsh
+++ b/src/it/it-update-property-005/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<api>3.0</api>" ) < 0 )
+    {
+        System.err.println( "Version should have been updated to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-releases-004/invoker.properties
+++ b/src/it/it-use-latest-releases-004/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases

--- a/src/it/it-use-latest-releases-004/pom.xml
+++ b/src/it/it-use-latest-releases-004/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-latest-releases-004/verify.bsh
+++ b/src/it/it-use-latest-releases-004/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>3.0</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-releases-005/invoker.properties
+++ b/src/it/it-use-latest-releases-005/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases -DresolveLatest=false

--- a/src/it/it-use-latest-releases-005/pom.xml
+++ b/src/it/it-use-latest-releases-005/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-latest-releases-005/verify.bsh
+++ b/src/it/it-use-latest-releases-005/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>LATEST</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api should not have been resolved from LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-versions-004/invoker.properties
+++ b/src/it/it-use-latest-versions-004/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-versions

--- a/src/it/it-use-latest-versions-004/pom.xml
+++ b/src/it/it-use-latest-versions-004/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-latest-versions-004/verify.bsh
+++ b/src/it/it-use-latest-versions-004/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>3.0</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-versions-005/invoker.properties
+++ b/src/it/it-use-latest-versions-005/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-versions -DresolveLatest=false

--- a/src/it/it-use-latest-versions-005/pom.xml
+++ b/src/it/it-use-latest-versions-005/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-latest-versions-005/verify.bsh
+++ b/src/it/it-use-latest-versions-005/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>LATEST</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api should not have been resolved from LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-releases-005/invoker.properties
+++ b/src/it/it-use-next-releases-005/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-releases -DresolveLatest=false

--- a/src/it/it-use-next-releases-005/pom.xml
+++ b/src/it/it-use-next-releases-005/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-next-releases-005/verify.bsh
+++ b/src/it/it-use-next-releases-005/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>LATEST</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api should not have been resolved from LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-snapshots-003/invoker.properties
+++ b/src/it/it-use-next-snapshots-003/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-snapshots -DresolveLatest=false

--- a/src/it/it-use-next-snapshots-003/pom.xml
+++ b/src/it/it-use-next-snapshots-003/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-next-snapshots-003/verify.bsh
+++ b/src/it/it-use-next-snapshots-003/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>LATEST</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api should not have been resolved from LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-versions-004/invoker.properties
+++ b/src/it/it-use-next-versions-004/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-versions -DresolveLatest=false

--- a/src/it/it-use-next-versions-004/pom.xml
+++ b/src/it/it-use-next-versions-004/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-next-versions-004/verify.bsh
+++ b/src/it/it-use-next-versions-004/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>LATEST</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api should not have been resolved from LATEST" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -180,6 +180,15 @@ public abstract class AbstractVersionsUpdaterMojo
     protected Boolean allowSnapshots;
 
     /**
+     * Resolve versions defined as LATEST (or RELEASE) to a specific version during updates. Does not work with update-parent goal. Ignored by
+     * reporting goals.
+     *
+     * @parameter property="resolveLatest" default-value="true"
+     * @since 1.4
+     */
+    protected Boolean resolveLatest;
+
+    /**
      * Our versions helper.
      */
     private VersionsHelper helper;
@@ -501,7 +510,7 @@ public abstract class AbstractVersionsUpdaterMojo
     {
         ArtifactVersion winner =
             version.getNewestVersion( currentVersion, property, this.allowSnapshots, this.reactorProjects,
-                                      this.getHelper() );
+                                      this.getHelper(), this.resolveLatest);
 
         if ( winner == null || currentVersion.equals( winner.toString() ) )
         {

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -112,7 +112,7 @@ public class DisplayPropertyUpdatesMojo
 
             ArtifactVersion winner =
                 version.getNewestVersion( currentVersion, property, this.allowSnapshots, this.reactorProjects,
-                                          this.getHelper() );
+                                          this.getHelper(), this.resolveLatest );
 
             if ( winner != null && !currentVersion.equals( winner.toString() ) )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
@@ -87,15 +87,7 @@ public class UpdateParentMojo
             version = parentVersion;
         }
 
-        VersionRange versionRange;
-        try
-        {
-            versionRange = VersionRange.createFromVersionSpec( version );
-        }
-        catch ( InvalidVersionSpecificationException e )
-        {
-            throw new MojoExecutionException( "Invalid version range specification: " + version, e );
-        }
+        VersionRange versionRange = getHelper().createVersionRange( version );
 
         Artifact artifact = artifactFactory.createDependencyArtifact( getProject().getParent().getGroupId(),
                                                                       getProject().getParent().getArtifactId(),

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -51,7 +51,7 @@ public class UpdatePropertyMojo
     private String property = null;
 
     /**
-     * The new version to set the property to (can be a version range to find a version within).
+     * Constrain the possible new versions by given Maven version range. To force a specific version you must use [1.0].
      *
      * @parameter property="newVersion"
      * @since 1.3

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -43,6 +43,15 @@ public class UpdatePropertyMojo
 // ------------------------------ FIELDS ------------------------------
 
     /**
+     * Any restrictions that apply to specific properties. Note only the designated property will be changed and the
+     * value of newVersion supercedes anything from the plugin configuration.
+     *
+     * @parameter
+     * @since 2.3
+     */
+    private Property[] properties = new Property[0];
+
+    /**
      * The property to update.
      *
      * @parameter property="property"
@@ -71,6 +80,18 @@ public class UpdatePropertyMojo
 
 // -------------------------- STATIC METHODS --------------------------
 
+    private static Property findProperty( String propertyName, Property... properties )
+    {
+        for ( Property property : properties )
+        {
+            if ( propertyName.equals( property.getName() ) )
+            {
+                return property;
+            }
+        }
+        return new Property( propertyName );
+    }
+
     // -------------------------- OTHER METHODS --------------------------
 
     /**
@@ -84,8 +105,12 @@ public class UpdatePropertyMojo
     protected void update( ModifiedPomXMLEventReader pom )
         throws MojoExecutionException, MojoFailureException, XMLStreamException
     {
-        Property propertyConfig = new Property( property );
-        propertyConfig.setVersion( newVersion );
+        Property propertyConfig = findProperty( property, properties );
+        if (newVersion!=null)
+        {
+            propertyConfig.setVersion( newVersion );
+        }
+
         Map<Property, PropertyVersions> propertyVersions =
             this.getHelper().getVersionPropertiesMap( getProject(), new Property[]{ propertyConfig }, property, "",
                                                       !Boolean.FALSE.equals( autoLinkItems ) );

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -43,9 +43,10 @@ public class UpdatePropertyMojo
 // ------------------------------ FIELDS ------------------------------
 
     /**
-     * A property to update.
+     * The property to update.
      *
      * @parameter property="property"
+     * @required
      * @since 1.3
      */
     private String property = null;

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -52,6 +52,8 @@ public class UpdatePropertyMojo
 
     /**
      * Constrain the possible new versions by given Maven version range. To force a specific version you must use [1.0].
+     * To set as the special version LATEST (or RELEASE) you should use (plain) LATEST and additionally set
+     * resolveLatest to false.
      *
      * @parameter property="newVersion"
      * @since 1.3

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -145,7 +145,7 @@ public class UseLatestReleasesMojo
 
                 getLog().debug( "Looking for newer versions of " + toString( dep ) );
                 ArtifactVersions versions = getHelper().lookupArtifactVersions( artifact, false );
-                ArtifactVersion[] newer = versions.getNewerVersions( version, segment, false );
+                ArtifactVersion[] newer = versions.getNewerVersions( version, segment, false, Boolean.TRUE.equals( resolveLatest ) );
                 newer = filterVersionsWithIncludes( newer, artifact );
                 if ( newer.length > 0 )
                 {

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -153,7 +153,7 @@ public class UseLatestSnapshotsMojo
                 ArtifactVersion upperBound =
                     segment >= 0 ? versionComparator.incrementSegment( lowerBound, segment ) : null;
                 getLog().info( "Upper bound: " + ( upperBound == null ? "none" : upperBound.toString() ) );
-                ArtifactVersion[] newer = versions.getVersions( lowerBound, upperBound, true, false, false );
+                ArtifactVersion[] newer = versions.getVersions( lowerBound, upperBound, true, false, false, resolveLatest );
                 getLog().debug( "Candidate versions " + Arrays.asList( newer ) );
                 String latestVersion = null;
                 for ( int j = 0; j < newer.length; j++ )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -127,7 +127,7 @@ public class UseLatestVersionsMojo
             getLog().debug( "Looking for newer versions of " + toString( dep ) );
             ArtifactVersions versions = getHelper().lookupArtifactVersions( artifact, false );
             ArtifactVersion[] newer =
-                versions.getNewerVersions( version, segment, Boolean.TRUE.equals( allowSnapshots ) );
+                versions.getNewerVersions( version, segment, Boolean.TRUE.equals( allowSnapshots ), Boolean.TRUE.equals(resolveLatest) );
             if ( newer.length > 0 )
             {
                 String newVersion = newer[newer.length - 1].toString();

--- a/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -107,7 +107,7 @@ public class UseNextReleasesMojo
                 }
 
                 ArtifactVersions versions = getHelper().lookupArtifactVersions( artifact, false );
-                ArtifactVersion[] newer = versions.getNewerVersions( version, false );
+                ArtifactVersion[] newer = versions.getNewerVersions( version, false, Boolean.TRUE.equals( resolveLatest ) );
                 if ( newer.length > 0 )
                 {
                     String newVersion = newer[0].toString();

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -153,7 +153,7 @@ public class UseNextSnapshotsMojo
                 ArtifactVersion upperBound =
                     segment >= 0 ? versionComparator.incrementSegment( lowerBound, segment ) : null;
                 getLog().info( "Upper bound: " + ( upperBound == null ? "none" : upperBound.toString() ) );
-                ArtifactVersion[] newer = versions.getVersions( lowerBound, upperBound, true, false, false );
+                ArtifactVersion[] newer = versions.getVersions( lowerBound, upperBound, true, false, false, resolveLatest );
                 getLog().debug( "Candidate versions " + Arrays.asList( newer ) );
                 for ( int j = 0; j < newer.length; j++ )
                 {

--- a/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
@@ -103,7 +103,7 @@ public class UseNextVersionsMojo
             getLog().debug( "Looking for newer versions of " + toString( dep ) );
             ArtifactVersions versions =
                 getHelper().lookupArtifactVersions( artifact, Boolean.TRUE.equals( allowSnapshots ) );
-            ArtifactVersion[] newer = versions.getNewerVersions( version, false );
+            ArtifactVersion[] newer = versions.getNewerVersions( version, false, Boolean.TRUE.equals( resolveLatest ) );
             if ( newer.length > 0 )
             {
                 String newVersion = newer[0].toString();

--- a/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -941,6 +941,29 @@ public class DefaultVersionsHelper
         return propertyVersions;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public VersionRange createVersionRange( String version ) throws MojoExecutionException
+    {
+        if ( "RELEASE".equals( version ) || "LATEST".equals( version ) )
+        {
+            return VersionRange.createFromVersion( version );
+        }
+        else if ( version != null )
+        {
+            try
+            {
+                return VersionRange.createFromVersionSpec( version );
+            }
+            catch ( InvalidVersionSpecificationException e )
+            {
+                throw new MojoExecutionException( e.getMessage(), e );
+            }
+        }
+        return null;
+    }
+
     // This is a data container to hold the result of a Dependency lookup to its ArtifactVersions.
     private static class DependencyArtifactVersions
     {

--- a/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
@@ -40,6 +40,8 @@ public abstract class UpdateScope
     implements Comparable, Serializable
 {
 
+    static final boolean RESOLVE_LATEST = true; // Being fixed means this reports will over-report possible updates
+
     /**
      * Versions which are less than an incremental update.
      *
@@ -68,7 +70,7 @@ public abstract class UpdateScope
                 ? null
                 : versionDetails.getNewestVersion( currentVersion,
                                                    versionComparator.incrementSegment( currentVersion, 2 ),
-                                                   includeSnapshots, false, false );
+                                                   includeSnapshots, false, false, RESOLVE_LATEST );
         }
 
         /** {@inheritDoc} */
@@ -79,7 +81,7 @@ public abstract class UpdateScope
             return versionComparator.getSegmentCount( currentVersion ) < 3
                 ? null
                 : versionDetails.getVersions( currentVersion, versionComparator.incrementSegment( currentVersion, 2 ),
-                                              includeSnapshots, false, false );
+                                              includeSnapshots, false, false, RESOLVE_LATEST );
         }
 
     };
@@ -113,7 +115,7 @@ public abstract class UpdateScope
                 ? null
                 : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
                                                    versionComparator.incrementSegment( currentVersion, 1 ),
-                                                   includeSnapshots, true, false );
+                                                   includeSnapshots, true, false, RESOLVE_LATEST );
         }
 
         /** {@inheritDoc} */
@@ -125,7 +127,7 @@ public abstract class UpdateScope
                 ? null
                 : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 2 ),
                                               versionComparator.incrementSegment( currentVersion, 1 ), includeSnapshots,
-                                              true, false );
+                                              true, false, RESOLVE_LATEST );
         }
 
     };
@@ -159,7 +161,7 @@ public abstract class UpdateScope
                 ? null
                 : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
                                                    versionComparator.incrementSegment( currentVersion, 0 ),
-                                                   includeSnapshots, true, false );
+                                                   includeSnapshots, true, false, RESOLVE_LATEST );
         }
 
         /** {@inheritDoc} */
@@ -171,7 +173,7 @@ public abstract class UpdateScope
                 ? null
                 : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 1 ),
                                               versionComparator.incrementSegment( currentVersion, 0 ), includeSnapshots,
-                                              true, false );
+                                              true, false, RESOLVE_LATEST );
         }
 
     };
@@ -203,7 +205,7 @@ public abstract class UpdateScope
             return versionComparator.getSegmentCount( currentVersion ) < 1
                 ? null
                 : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 0 ), null,
-                                                   includeSnapshots, true, false );
+                                                   includeSnapshots, true, false, RESOLVE_LATEST );
         }
 
         /** {@inheritDoc} */
@@ -214,7 +216,7 @@ public abstract class UpdateScope
             return versionComparator.getSegmentCount( currentVersion ) < 1
                 ? null
                 : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 0 ), null,
-                                              includeSnapshots, true, false );
+                                              includeSnapshots, true, false, RESOLVE_LATEST );
         }
 
     };
@@ -237,14 +239,14 @@ public abstract class UpdateScope
         public ArtifactVersion getNewestUpdate( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                 boolean includeSnapshots )
         {
-            return versionDetails.getNewestVersion( currentVersion, null, includeSnapshots, false, false );
+            return versionDetails.getNewestVersion( currentVersion, null, includeSnapshots, false, false, RESOLVE_LATEST );
         }
 
         /** {@inheritDoc} */
         public ArtifactVersion[] getAllUpdates( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                 boolean includeSnapshots )
         {
-            return versionDetails.getVersions( currentVersion, null, includeSnapshots, false, false );
+            return versionDetails.getVersions( currentVersion, null, includeSnapshots, false, false, RESOLVE_LATEST );
         }
 
     };

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -66,23 +66,15 @@ public interface VersionDetails
     ArtifactVersion[] getVersions( boolean includeSnapshots );
 
     /**
-     * Returns all available versions within the specified version range.
-     *
-     * @param versionRange     The version range within which the version must exist.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return all available versions within the specified version range.
-     * @since 1.0-alpha-3
-     */
-    ArtifactVersion[] getVersions( VersionRange versionRange, boolean includeSnapshots );
-
-    /**
      * Returns all available versions within the specified bounds.
      *
      * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
      * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
+     * @deprecated Test-only method
      */
+    @Deprecated
     ArtifactVersion[] getVersions( ArtifactVersion lowerBound, ArtifactVersion upperBound );
 
     /**
@@ -91,10 +83,11 @@ public interface VersionDetails
      * @param lowerBound       the lower bound or <code>null</code> if the lower limit is unbounded.
      * @param upperBound       the upper bound or <code>null</code> if the upper limit is unbounded.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param resolveLatest    <code>true</code> if LATEST (or RELEASE) should be resovled to a specific version.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
-    ArtifactVersion[] getVersions( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots );
+    ArtifactVersion[] getVersions( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots, boolean resolveLatest );
 
     /**
      * Returns all available versions within the specified bounds.
@@ -104,11 +97,12 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @param includeLower     <code>true</code> if the lower bound is inclusive.
      * @param includeUpper     <code>true> if the upper bound is inclusive.
+     * @param resolveLatest    <code>true</code> if LATEST (or RELEASE) should be resovled to a specific version.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
     ArtifactVersion[] getVersions( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
-                                   boolean includeLower, boolean includeUpper );
+                                   boolean includeLower, boolean includeUpper, boolean resolveLatest );
 
     /**
      * Returns all available versions within the specified bounds.
@@ -120,11 +114,13 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @param includeLower     <code>true</code> if the lower bound is inclusive.
      * @param includeUpper     <code>true> if the upper bound is inclusive.
+     * @param resolveLatest    <code>true</code> if LATEST (or RELEASE) should be resovled to a specific version.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
     ArtifactVersion[] getVersions( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
-                                   boolean includeSnapshots, boolean includeLower, boolean includeUpper );
+                                   boolean includeSnapshots, boolean includeLower, boolean includeUpper,
+                                   boolean resolveLatest );
 
     /**
      * Returns the latest version newer than the specified lowerBound, but less than the specified upper bound or
@@ -134,7 +130,9 @@ public interface VersionDetails
      * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
      * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-alpha-3
+     * @deprecated Test-only method!
      */
+    @Deprecated
     ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound );
 
     /**
@@ -144,12 +142,13 @@ public interface VersionDetails
      * @param lowerBound       the lower bound or <code>null</code> if the lower limit is unbounded.
      * @param upperBound       the upper bound or <code>null</code> if the upper limit is unbounded.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param resolveLatest    <code>true</code> if LATEST (or RELEASE) should be resovled to a specific version.
      * @return the latest version between currentVersion and upperBound or <code>null</code> if no version is
      *         available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound,
-                                      boolean includeSnapshots );
+                                      boolean includeSnapshots, boolean resolveLatest );
 
     /**
      * Returns the latest version newer than the specified current version, but less than the specified upper bound or
@@ -160,11 +159,12 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @param includeLower     <code>true</code> if the lower bound is inclusive.
      * @param includeUpper     <code>true> if the upper bound is inclusive.
+     * @param resolveLatest    <code>true</code> if LATEST (or RELEASE) should be resovled to a specific version.
      * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
-                                      boolean includeLower, boolean includeUpper );
+                                      boolean includeLower, boolean includeUpper, boolean resolveLatest );
 
     /**
      * Returns the latest version newer than the specified current version, but less than the specified upper bound or
@@ -177,11 +177,13 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @param includeLower     <code>true</code> if the lower bound is inclusive.
      * @param includeUpper     <code>true> if the upper bound is inclusive.
+     * @param resolveLatest    <code>true</code> if LATEST (or RELEASE) should be resovled to a specific version.
      * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
-                                      boolean includeSnapshots, boolean includeLower, boolean includeUpper );
+                                      boolean includeSnapshots, boolean includeLower, boolean includeUpper,
+                                      boolean resolveLatest );
 
     /**
      * Returns the latest version within the specified version range or <code>null</code> if no such version exists.

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
@@ -277,4 +277,14 @@ public interface VersionsHelper
      */
     void resolveArtifact( Artifact artifact, boolean usePluginRepositories )
         throws ArtifactResolutionException, ArtifactNotFoundException;
+
+    /**
+     * Parse a version string into a {@link VersionRange} with support for LATEST and RELEASE versions.
+     *
+     * @param version unparsed version (range). E.g. 1.0, LATEST, [1.0,2.0).
+     * @return null if input was null.
+     * @throws MojoExecutionException if something goes wrong.
+     */
+    VersionRange createVersionRange( String version )
+        throws MojoExecutionException;
 }

--- a/src/site/apt/examples/update-properties.apt.vm
+++ b/src/site/apt/examples/update-properties.apt.vm
@@ -143,6 +143,19 @@ Version selection
   Inclusion of snapshots can be controlled with the <<<allowSnapshots>>> parameter as can inclusion of other reactor
   projects (<<<excludeReactor>>>).
 
+* Working with LATEST or RELEASE
+
+  Maven dependencies can be specified as <<<RELEASE>>> or <<<LATEST>>> (includes snapshots). By default, updating
+  properties resolves these labels to specific versions when it encounters them. This behaviour can be disabled through
+  the <<<resolveLatest>>> parameter. If disabled, these labels will count as newer than any specific version so will not
+  get changed (i.e. updating a property set to <<<LATEST>>> will not change it to a specific version).
+
+  You can also assign these labels to a property with:
+
+---
+mvn versions:update-property -Dproperty=bom.version -DnewVersion=LATEST
+---
+
 * Property-specific versioning rules
 
   Some general parameters can be overridden for individual properties via the plugin's configuration

--- a/src/site/apt/examples/update-properties.apt.vm
+++ b/src/site/apt/examples/update-properties.apt.vm
@@ -23,7 +23,7 @@
  2009-03-27
  ------
 
-Update Properties
+Updating Properties
 
   This goal is useful when you define dependency versions using properties. For example if you have a suite of projects
   and you want to ensure that you use the same version of each dependency in the suite, you might have a dependency
@@ -31,373 +31,136 @@ Update Properties
 
 ---
 <project>
-  ...
-  <dependencies>
-    ...
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-core</artifactId>
-      <version>[${manchu.version}]</version>
-    </dependency>
-    ...
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-extra</artifactId>
-      <version>[${manchu.version}]</version>
-    </dependency>
-    ...
-  </dependencies>
-  ...
   <properties>
-    ...
-    <manchu.version>1.5.0</manchu.version>
-    ...
+    <org.junit.version>4.11</org.junit.version>
+    <org.hamcrest.version>1.2</org.hamcrest.version>
+    <org.springframework.version>3.2.8</org.springframework.version>
   </properties>
-  ...
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${org.junit.version}</version> <!-- strongly recommend this version -->
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>[${org.hamcrest.version}]</version> <!-- force this version -->
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>[${org.hamcrest.version}]</version> <!-- force this version -->
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>[${org.springframework.version},4.0.0)</version> <!-- must be less than 4.0.0 -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>
 ---
 
-  The aim being to allow updating the version of all the suite components in one go.  The versions-maven-plugin can help
-  you to automate these updates.
+Which properties are evaluated?
 
-  By default, the versions-maven-plugin will look at the dependencies in your POM.  If any dependencies declare a version
-  which depends on evaluating a single property that is defined in the POM, for example:
+* Updating multiple properties
+
+  Executing the <<<update-properties>>> goal will evaluate all properties to the latest version available to you (based
+  on your reactor, local repository and all currently active remote repositories).
+
+   * Properties not in active Profiles are not evaluated.
+    * A good use of this is where alternative <release> and <development> profiles can be updated independantly.
+   * Only properties which can be associated with Maven dependencies are evaluated
+    * The plugin does not allow you set arbitrary properties (or to arbitrary values).
+
+  Updates can be restricted to properties pertaining to specific dependencies by using the <<<includes>>> and
+  <<<excludes>>> parameters. These parameters follow the format <<<groupId:artifactId:type:classifier>>>. Use a
+  comma-separated list to specify multiple includes. Wildcards (*) can also be used to match multiple values.
 
 ---
-    <!-- strongly recommend this version -->
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-core</artifactId>
-      <version>${manchu.version}</version>
-    </dependency>
-
-    <!-- force this version -->
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-core</artifactId>
-      <version>[${manchu.version}]</version>
-    </dependency>
-
-    <!-- any version between this version and 2.0.0, excluding 2.0.0 and 2.0.0-SNAPSHOT -->
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-core</artifactId>
-      <version>[${manchu.version},2.0.0-!)</version>
-    </dependency>
-
-    <!-- any version between version 1.0.0 and this version inclusive -->
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-core</artifactId>
-      <version>[1.0.0,${manchu.version}]</version>
-    </dependency>
+mvn versions:update-properties -Dexcludes=internal.groupid:*,org.springframework:* -DallowSnapshots=false
+mvn versions:update-properties -Dincludes=internal.groupid:* -DallowSnapshots=true
 ---
 
-  If multiple dependencies use the property to define the version, then the all dependencies will be used to determine
-  what versions are available (and consequently what version to update the property to).  The version chosen in such 
+  Alternatively you can supply an explicit comma-separated list of names with parameter <<<includeProperties>>>:
+
+---
+mvn versions:update-properties -DincludeProperties=org.springframework.version
+---
+
+* Updating single properties
+
+  The <<<update-property>>> goal allows a single property to be updated to a specific value (defined as a Maven version
+  range). To force a specific version you must use range notation (e.g. [3.2.9])
+
+---
+mvn versions:update-property -Dproperty=org.springframework.version -DnewVersion=(,3.3)
+---
+
+
+Dependency associations
+
+  By default, the plugin will scan your POM for dependencies declaring a version which depends on evaluating a single
+  property that is defined in the same POM. This is controlled by the <<<autoLinkItems>>> parameter.
+
+  If multiple dependencies use the same property to define their version (e.g. <<<org.hamcrest.version>>> in the initial
+  example), then they all will be used to determine what versions are available. The property version chosen in such
   cases must be available for all associated dependencies.
 
-  The automatic detection can be assisted by adding a version-maven-plugin configuration section to the POM,
-  for example if we add the following to the POM:
+  In cases where the automatic linkage cannot be determined (for example a child POM overriding a property defined in a
+  parent), plugin configuration can specify the association:
 
 ---
+<plugin>
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>versions-maven-plugin</artifactId>
+  <configuration>
+    <properties>
+      <property>
+        <name>bom.version</name>
+        <autoLinkDependencies>false</autoLinkDependencies> <!-- Disable auto-link so only our config matters -->
+        <dependencies>
+          <dependency>
+            <groupId>my.groupid</groupId>
+            <artifactId>bom</artifactId> <!-- Explicitly assign association agaisnt this dependency -->
+            <version>[1.0.0,2.0.0-!)</version> <!-- Must be less than 2.0.0-SNAPSHOT -->
+          </dependency>
+        </dependencies>
+      </property>
+    </properties>
+  </configuration>
+</plugin>
+---
+
+Version selection
+
+  The plugin will honour any version range boundaries specified for the dependencies associated with a property.
+  Inclusion of snapshots can be controlled with the <<<allowSnapshots>>> parameter as can inclusion of other reactor
+  projects (<<<excludeReactor>>>).
+
+* Property-specific versioning rules
+
+  Some general parameters can be overridden for individual properties via the plugin's configuration
+
+---
+<plugin>
+ <groupId>org.codehaus.mojo</groupId>
+ <artifactId>versions-maven-plugin</artifactId>
+ <configuration>
+   <properties>
+     <property>
+       <name>some.property</name>
+       <preferReactor>false</preferReactor> <!-- Stop reactor version always winning -->
+       <searchReactor>false</searchReactor> <!-- Do not include reactor searching at all -->
+     </property>
+   </properties>
+ </configuration>
+</plugin>
 <project>
-  ...
-  <build>
-    ...
-    <plugins>
-      ...
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${pluginVersion}</version>
-        <configuration>
-          ...
-          <properties>
-            ...
-            <property>
-              <name>manchu.version</name>
-              ...
-              <dependencies>
-                <dependency>
-                  <groupId>com.foo.bar</groupId>
-                  <artifactId>manchu-wibble</artifactId>
-                </dependency>
-                ...
-              </dependencies>
-              ...
-            </property>
-          </properties>
-          ...
-        </configuration>
-      </plugin>
-      ...
-    </plugins>
-    ...
-  </build>
-  ...
-</project>
 ---
-
-  Then executing the <<<update-properties>>> goal will update the <<<manchu.version>>> property to the latest common 
-  version of both manchu-core and manchu-wibble available to  you (i.e. based on your local repository and all 
-  currently active remote repositories).
-
-  If you want to restrict updates to within a specific range, for example, suppose we only want the 1.5 stream of
-  manchu:
-
----
-<project>
-  ...
-  <build>
-    ...
-    <plugins>
-      ...
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${pluginVersion}</version>
-        <configuration>
-          ...
-          <properties>
-            ...
-            <property>
-              <name>manchu.version</name>
-              ...
-              <version>[1.5.0,1.6.0-!)</version>
-              ...
-            </property>
-            ...
-          </properties>
-          ...
-        </configuration>
-      </plugin>
-      ...
-    </plugins>
-    ...
-  </build>
-  ...
-</project>
----
-
-  Additionally, if you want to disable the automatic detection of properties set the autoLinkItemDependencies to false
-
----
-<project>
-  ...
-  <build>
-    ...
-    <plugins>
-      ...
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${pluginVersion}</version>
-        <configuration>
-          ...
-          <properties>
-            ...
-            <property>
-              <name>manchu.version</name>
-              ...
-              <autoLinkDependencies>false</autoLinkDependencies>
-              ...
-            </property>
-            ...
-          </properties>
-          ...
-        </configuration>
-      </plugin>
-      ...
-    </plugins>
-    ...
-  </build>
-  ...
-</project>
----
-
-
-  By default, the reactor will also be searched to see if it can satisfy the property's associated dependencies.
-  If you want to disable the preference given to the reactor (i.e. stop the reactor version always winning)
-
----
-<project>
-  ...
-  <build>
-    ...
-    <plugins>
-      ...
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${pluginVersion}</version>
-        <configuration>
-          ...
-          <properties>
-            ...
-            <property>
-              <name>manchu.version</name>
-              ...
-              <preferReactor>false</preferReactor>
-              ...
-            </property>
-            ...
-          </properties>
-          ...
-        </configuration>
-      </plugin>
-      ...
-    </plugins>
-    ...
-  </build>
-  ...
-</project>
----
-
-  If you want to disable the searching the reactor at all:
-
----
-<project>
-  ...
-  <build>
-    ...
-    <plugins>
-      ...
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${pluginVersion}</version>
-        <configuration>
-          ...
-          <properties>
-            ...
-            <property>
-              <name>manchu.version</name>
-              ...
-              <searchReactor>false</searchReactor>
-              ...
-            </property>
-            ...
-          </properties>
-          ...
-        </configuration>
-      </plugin>
-      ...
-    </plugins>
-    ...
-  </build>
-  ...
-</project>
----
-
-  The allowSnapshots property and configuration option allow the inclusion of snapshots, if you want to ensure that
-  snapshots are never resolved,
-
----
-<project>
-  ...
-  <build>
-    ...
-    <plugins>
-      ...
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${pluginVersion}</version>
-        <configuration>
-          ...
-          <allowSnapshots>true</allowSnapshots> <!-- in general allow them -->          
-          ...
-          <properties>
-            ...
-            <property>
-              <name>manchu.version</name>
-              ...
-              <banSnapshots>true</banSnapshots> <!-- but never for this property -->
-              ...
-            </property>
-            ...
-          </properties>
-          ...
-        </configuration>
-      </plugin>
-      ...
-    </plugins>
-    ...
-  </build>
-  ...
-</project>
----
-
-* Restricting the properties to be updated using includes / excludes
-
-  The <<includes>> and <<excludes>>> parameters follow the format <<<groupId:artifactId:type:classifier>>>.
-  Use a comma separated separated list to specify multiple includes.  Wildcards (*) can also be used to match
-  multiple values.
-
-  This example will match anything with the groupId "org.codehaus.plexus" and anything with the groupId and
-  artifactId matching "junit".
-
-  Only properties that map to artifacts that are allowed by the inclusion and exclusion patterns will be updated.
-
-  With a project that looks like this:
-
----
-<project>
-  ...
-  <dependencies>
-    ...
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-core</artifactId>
-      <version>[${manchu.version}]</version>
-    </dependency>
-    ...
-    <dependency>
-      <groupId>com.foo.bar</groupId>
-      <artifactId>manchu-extra</artifactId>
-      <version>[${manchu.version}]</version>
-    </dependency>
-    ...
-    <dependency>
-      <groupId>org.blarg</groupId>
-      <artifactId>blarg-framework</artifactId>
-      <version>[${blarg.version}]</version>
-    </dependency>
-    ...
-  </dependencies>
-  ...
-  <properties>
-    ...
-    <manchu.version>1.5.0</manchu.version>
-    <blarg.version>3.1.0.RELEASE</blarg.version>
-    ...
-  </properties>
-  ...
-</project>
----
-
-  To update the property for only the "com.foo.bar" dependencies, you can run:
-
-+---+
-mvn versions:use-releases -Dincludes=com.foo.bar:*
-+---+
-
-  Would result in the property for the manchu.version being updated, but not the blarg.version property.
-
-  In the above example, you could achieve the same result using:
-
-+---+
-mvn versions:use-releases -Dexcludes=org.blarg:*
-+---+
-
-  If a property is used by artifacts that are not allowed by the set of specified <<includes>> and <<excludes>> then the property
-  will not be updated.
-
-
-
-
-
-
-
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -128,6 +128,16 @@ mvn -N versions:update-child-modules
   This goal helps when you use properties to define versions.  Please see the
   {{{./examples/update-properties.html}<<<update-properties>>> example}}.
 
+---
+mvn versions:update-properties -Dincludes=com.my.groupId
+---
+
+  Individual properties can be updated by name and can be set to specific versions.
+
+---
+mvn versions:update-property -Dproperty=junit.version -DnewVersion=[4.11]
+---
+
 ** Updating versions of dependencies (Note: modifies <<<pom.xml>>> files)
 
   There are a set of goals to help with advancing dependency versions: <<<use-latest-releases>>>, 

--- a/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
@@ -20,7 +20,6 @@ package org.codehaus.mojo.versions.api;
  */
 
 import junit.framework.TestCase;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.DefaultArtifactFactory;
 import org.apache.maven.artifact.manager.DefaultWagonManager;
@@ -32,6 +31,7 @@ import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.artifact.resolver.DefaultArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
@@ -42,24 +42,18 @@ import org.apache.maven.wagon.UnsupportedProtocolException;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.file.FileWagon;
 import org.apache.maven.wagon.repository.Repository;
-import org.apache.maven.execution.MavenSession;
 import org.codehaus.mojo.versions.Property;
 import org.codehaus.mojo.versions.ordering.VersionComparators;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.hasToString;
 import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.hasItem;
 import static org.junit.matchers.JUnitMatchers.hasItems;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.*;
 
 /**
  * Test {@link DefaultVersionsHelper}
@@ -175,6 +169,16 @@ public class DefaultVersionsHelperTest
         assertTrue( result.isEmpty() );
     }
 
+    public void testVersionRange()
+        throws MojoExecutionException
+    {
+        VersionsHelper helper = createHelper();
+
+        assertThat( helper.createVersionRange( "1.0" ), hasToString( "1.0" ) );
+        assertThat( helper.createVersionRange( "[1.0,2.0)" ), hasToString( "[1.0,2.0)" ) );
+        assertThat( helper.createVersionRange( "LATEST" ), hasToString( "LATEST" ) );
+        assertThat( helper.createVersionRange( "RELEASE" ), hasToString( "RELEASE" ) );
+    }
 
     private VersionsHelper createHelper()
         throws MojoExecutionException


### PR DESCRIPTION
1 Adds resolveLatest parameter to many mojos which (if set to false) supports LATEST/RELEASE keywords being retained instead of resolved to real versions (fixes #31)
- test cases
- documentation

2 Fixed update-property to use the same configuration/properties POM config that update-properties does
- test cases

3 Rewrote mojo docs for updating properties as they were misleading 

4 Fixed an NPE if you call update-property without specifying -Dproperty

Should all be formatted to Maven standard.
