### PR TITLE
Fix locking of snapshots with classifier

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
@@ -20,6 +20,7 @@ package org.codehaus.mojo.versions;
  */
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -189,10 +190,12 @@ public class LockSnapshotsMojo
 
         String lockedVersion = dep.getVersion();
 
-        Artifact depArtifact = artifactFactory.createArtifact( dep.getGroupId(), dep.getArtifactId(), dep.getVersion(),
-                                                               dep.getScope(), dep.getType() );
         try
         {
+            Artifact depArtifact = artifactFactory.createDependencyArtifact(
+                    dep.getGroupId(), dep.getArtifactId(),
+                    VersionRange.createFromVersionSpec(dep.getVersion()),
+                    dep.getType(), dep.getClassifier(), dep.getScope());
             resolver.resolve( depArtifact, getProject().getRemoteArtifactRepositories(), localRepository );
 
             lockedVersion = depArtifact.getVersion();


### PR DESCRIPTION
This fixes resolution of snapshot dependencies with classifiers.

If you depended on ex. a class tests of packaging jar from a artifact with no jar without packaging the previous snapshot resolution would fail.
