### PR TITLE
Always provide latest release version.

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/api/PropertyVersions.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PropertyVersions.java
@@ -333,8 +333,9 @@ public class PropertyVersions
         {
             throw new MojoExecutionException( e.getMessage(), e );
         }
-        ArtifactVersion result = getNewestVersion( range, helper.createArtifactVersion( currentVersion ), null,
-                                                   includeSnapshots, false, true );
+        ArtifactVersion result = getNewestVersion( range, includeSnapshots ? 
+                                   helper.createArtifactVersion( currentVersion ) : null, null, includeSnapshots, false,
+                                   true );
         helper.getLog().debug( "Property ${" + property.getName() + "}: Current winner is: " + result );
 
         if ( property.isSearchReactor() )


### PR DESCRIPTION
When updating versions, this will always provide the latest release version unless -DallowSnapshots=true

As an example, if I have a dependency A and it has version:

1.5.1-SNAPSHOT but the latest release in my repo is 1.5.0,
then the update will replace this version with 1.5.0.

If -DallowSnapshots=true is specified, then the version will be replaced with the latest snapshot.