### PR TITLE
[Bug 2.3] Classifier not correctly supported in lock-snaphots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target
 .project
 *.iml
 .idea
+release-me.sh
+settings.xml

--- a/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
@@ -183,14 +183,11 @@ public class LockSnapshotsMojo
      * @param dep
      * @return The timestamp version if exists, otherwise the original snapshot dependency version is returned.
      */
-    private String resolveSnapshotVersion( Dependency dep )
-    {
+    private String resolveSnapshotVersion( Dependency dep ) throws MojoExecutionException {
         getLog().debug( "Resolving snapshot version for dependency: " + dep );
 
         String lockedVersion = dep.getVersion();
-
-        Artifact depArtifact = artifactFactory.createArtifact( dep.getGroupId(), dep.getArtifactId(), dep.getVersion(),
-                                                               dep.getScope(), dep.getType() );
+        Artifact depArtifact = toArtifact(dep);
         try
         {
             resolver.resolve( depArtifact, getProject().getRemoteArtifactRepositories(), localRepository );

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -204,10 +204,8 @@ public class SetMojo
 
         try
         {
-            final MavenProject project =
-                PomHelper.getLocalRoot( projectBuilder, getProject(), localRepository, null, getLog() );
-
-            getLog().info( "Local aggregation root: " + project.getBasedir() );
+            final MavenProject project = getProject();
+            getLog().info( "Root project: " + project.getBasedir() );
             Map<String, Model> reactorModels = PomHelper.getReactorModels( project, getLog() );
             final SortedMap<String, Model> reactor =
                 new TreeMap<String, Model>( new ReactorDepthComparator( reactorModels ) );

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -265,14 +265,16 @@ public class SetMojo
     {
 
         getLog().debug( "Applying change " + groupId + ":" + artifactId + ":" + oldVersion + " -> " + newVersion );
+
         // this is a triggering change
         addChange( groupId, artifactId, oldVersion, newVersion );
         // now fake out the triggering change
+        if(files.size() > 0){
+            final Map.Entry<String, Model> current = PomHelper.getModelEntry( reactor, groupId, artifactId );
+            current.getValue().setVersion( newVersion );
+            addFile( files, project, current.getKey() );
+        }
 
-        final Map.Entry<String, Model> current = PomHelper.getModelEntry( reactor, groupId, artifactId );
-        current.getValue().setVersion( newVersion );
-
-        addFile( files, project, current.getKey() );
 
         for ( Map.Entry<String, Model> sourceEntry : reactor.entrySet() )
         {

--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -110,6 +110,8 @@ public class UseReleasesMojo
                 }
 
                 getLog().debug( "Looking for a release of " + toString( dep ) );
+                //Force releaseVersion version because org.apache.maven.artifact.metadata.MavenMetadataSource does not retrieve release version if provided snapshot version.
+                artifact.setVersion(releaseVersion);
                 ArtifactVersions versions = getHelper().lookupArtifactVersions( artifact, false );
                 if ( versions.containsVersion( releaseVersion ) )
                 {


### PR DESCRIPTION
Fixed two bugs:
[Bug 2.3] Classifier not correctly supported in lock-snaphots + [Bug 2.3] Use-release not working 
