### PR TITLE
UseReleases: now with allowRangeMatching and failIfNotReplaced

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.versions;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -31,6 +32,7 @@ import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,9 +45,23 @@ import java.util.regex.Pattern;
  * @requiresDirectInvocation true
  * @since 1.0-alpha-3
  */
-public class UseReleasesMojo
-    extends AbstractVersionsDependencyUpdaterMojo
-{
+public class UseReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
+
+    /**
+     * Whether to check for releases within the range.
+     *
+     * @parameter property="allowRangeMatching" default-value="false"
+     * @since 2.3
+     */
+    private Boolean allowRangeMatching;
+
+    /**
+     * Whether to fail if a SNAPSHOT could not be replaced
+     *
+     * @parameter property="failIfNotReplaced" default-value="false"
+     * @since 2.3
+     */
+    private Boolean failIfNotReplaced;
 
     // ------------------------------ FIELDS ------------------------------
 
@@ -119,8 +135,36 @@ public class UseReleasesMojo
                         getLog().info( "Updated " + toString( dep ) + " to version " + releaseVersion );
                     }
                 }
+                else if ( allowRangeMatching )
+                {
+
+                    ArtifactVersion finalVersion = null;
+                    for (ArtifactVersion proposedVersion : versions.getVersions( false )) {
+                        if (proposedVersion.toString().startsWith( releaseVersion )) {
+                            getLog().debug("Found matching version for " + toString(dep) + " to version " + releaseVersion);
+                            finalVersion = proposedVersion;
+                        }
+                    }
+
+                    if ( finalVersion != null )
+                    {
+                        if (PomHelper.setDependencyVersion(pom, dep.getGroupId(), dep.getArtifactId(), version,
+                                finalVersion.toString()))
+                        {
+                            getLog().info("Updated " + toString(dep) + " to version " + finalVersion.toString());
+                        }
+                    } else
+                    {
+                        getLog().info("No matching release of " + toString(dep) + " to force.");
+                        if ( failIfNotReplaced ) {
+                            throw new NoSuchElementException("No matching release of " + toString(dep) + " to found for update.");
+                        }
+                    }
+
+                }
             }
         }
     }
+
 
 }


### PR DESCRIPTION
In order to use this plugin we had to enhance the behaviour of the `UseReleasesMojo`.

Before, if the version that should be replaced was `1.0-SNAPSHOT`, it would only look for a matching release with the version `1.0`.

Due to our continous-integration pipeline we needed the functionality that `1.0-SNAPSHOT` should be replaced with the highest matching version `1.0.x.y` (e.g. `1.0.1.100`).

This pull request implements this behaviour, it can be activated with the property `allowRangeMatching`. Also, if no matching snapshot is found, the property `failIfNotReplaced` causes the build to immediately fail.

Both properties default to `false` so that the default behaviour is not changed.

We considered using `force-releases`, but that had the effect, that `1.1-SNAPSHOT` would be resolved to `1.2` if such a version exists. We would like the upper-bound of the range to be respected (i.e. nothing above `1.1.x.y`).

We're looking forward to your comments and hope that this functionality is useful to others.