### PR TITLE
UseReleases: now with allowRangeMatching and failIfNotReplaced + test

### DIFF
--- a/src/it-repo/dummy-api-1.1-SNAPSHOT.pom
+++ b/src/it-repo/dummy-api-1.1-SNAPSHOT.pom
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>dummy-api</artifactId>
+  <version>1.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.4.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/it-use-releases-003/invoker.properties
+++ b/src/it/it-use-releases-003/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-releases -DallowRangeMatching=true -DfailIfNotReplaced=true

--- a/src/it/it-use-releases-003/pom.xml
+++ b/src/it/it-use-releases-003/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1-SNAPSHOT</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-use-releases-003/verify.bsh
+++ b/src/it/it-use-releases-003/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.1.3</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;


### PR DESCRIPTION
Second try, now with test (Replaces #86)

Original text:

In order to use this plugin we had to enhance the behaviour of the `UseReleasesMojo`.

Before, if the version that should be replaced was `1.0-SNAPSHOT`, it would only look for a matching release with the version `1.0`.

Due to our continous-integration pipeline we needed the functionality that `1.0-SNAPSHOT` should be replaced with the highest matching version `1.0.x.y` (e.g. `1.0.1.100`).

This pull request implements this behaviour, it can be activated with the property `allowRangeMatching`. Also, if no matching snapshot is found, the property `failIfNotReplaced` causes the build to immediately fail.

Both properties default to `false` so that the default behaviour is not changed.

We considered using `force-releases`, but that had the effect, that `1.1-SNAPSHOT` would be resolved to `1.2` if such a version exists. We would like the upper-bound of the range to be respected (i.e. nothing above `1.1.x.y`).

We're looking forward to your comments and hope that this functionality is useful to others.