### PR TITLE
versions:set: fix NullPointerException if project is in root directory

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -1395,7 +1395,7 @@ public class PomHelper
         while ( true )
         {
             final File parentDir = project.getBasedir().getParentFile();
-            if ( parentDir.isDirectory() )
+            if ( parentDir != null && parentDir.isDirectory() )
             {
                 logger.debug( "Checking to see if " + parentDir + " is an aggregator parent" );
                 File parent = new File( parentDir, "pom.xml" );


### PR DESCRIPTION
For example, a mapped drive in Windows
