### PR TITLE
Execute <use-releases> goal in the corresponding example instead of wrong <unlock-snapshot> goal

### DIFF
--- a/src/site/apt/examples/use-releases.apt
+++ b/src/site/apt/examples/use-releases.apt
@@ -45,7 +45,7 @@ Replacing -SNAPSHOT versions with their corresponding releases
   a corresponding release version, then it will replace the -SNAPSHOT with its corresponding release version.
 
 ---
-mvn versions:unlock-snapshots
+mvn versions:use-releases
 ---
 
   When org.codehaus.cargo:cargo-core-api releases the 1.0-alpha-7 version this would update the pom to look like:


### PR DESCRIPTION
Example of `use-releases` goal in documentation by mistake execute `unlock-snapshot` goal. 
This patch correct the command to execute in documentation.
