### PR TITLE
fix #113

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -322,7 +322,7 @@ public class SetMojo
         final Map.Entry<String, Model> current = PomHelper.getModelEntry( reactor, groupId, artifactId );
         current.getValue().setVersion( newVersion );
 
-        addFile( files, getProject(), current.getKey() );
+        addFile( files, project, current.getKey() );
 
         for ( Map.Entry<String, Model> sourceEntry : reactor.entrySet() )
         {


### PR DESCRIPTION
Fix a little mistake made by the commit bdb3784d6fbb717604e0578f1402b43f4f5ec735. The problem is that the `getProject()` method not always returns the aggregator project. I've made some tests and it appears that this pull request won't break any functionalities of bdb3784d6fbb717604e0578f1402b43f4f5ec735.