### PR TITLE
Fix wrong goal mentioned in docu

### DIFF
--- a/src/site/apt/examples/use-releases.apt
+++ b/src/site/apt/examples/use-releases.apt
@@ -45,7 +45,7 @@ Replacing -SNAPSHOT versions with their corresponding releases
   a corresponding release version, then it will replace the -SNAPSHOT with its corresponding release version.
 
 ---
-mvn versions:unlock-snapshots
+mvn versions:use-releases
 ---
 
   When org.codehaus.cargo:cargo-core-api releases the 1.0-alpha-7 version this would update the pom to look like:


### PR DESCRIPTION
"unlock-snapshots" goal used in documentation for goal "use-releases", but should be use-releases.
The dependency listed prior to mentioning the command contains a snapshot version. The dependency listed after mentioning the command contains the corresponding final version. The operation applied here is not related to "unlock-snapshots", but to "use-releases".