### PR TITLE
Add an option to SetMojo to set some properties to newVersion

### DIFF
--- a/src/it/it-set-010/invoker.properties
+++ b/src/it/it-set-010/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -DnewVersion=1.2.1-SNAPSHOT -DsetProperties=myProperty1
+invoker.nonRecursive=true
+invoker.buildResult=success

--- a/src/it/it-set-010/module-a1/pom.xml
+++ b/src/it/it-set-010/module-a1/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>project-a</artifactId>
+    <version>1.2.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a1</artifactId>
+  <packaging>pom</packaging>
+  <version>2.0.7-SNAPSHOT</version>
+
+</project>

--- a/src/it/it-set-010/module-a2/pom.xml
+++ b/src/it/it-set-010/module-a2/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>project-a</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a2</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0</version>
+
+  <properties>
+    <myProperty1>1.2.0</myProperty1>
+  </properties>
+
+</project>

--- a/src/it/it-set-010/pom.xml
+++ b/src/it/it-set-010/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>project-a</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0</version>
+  <name>mversions-71</name>
+
+  <description>
+    invoking versions:set on root module should not update child module versions
+    unless they are the same as the parent old version
+  </description>
+
+  <modules>
+    <module>module-a1</module>
+    <module>module-a2</module>
+  </modules>
+
+  <properties>
+    <myProperty1>1.2.0</myProperty1>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.2-beta-2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ear-plugin</artifactId>
+          <version>2.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ejb-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-rar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.0-beta-7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.0.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.1-alpha-1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/it-set-010/verify.bsh
+++ b/src/it/it-set-010/verify.bsh
@@ -1,0 +1,101 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+import java.util.regex.*;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+
+    BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    StringBuilder buf = new StringBuilder();
+    String line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    Pattern p = Pattern.compile( "\\Q<version>\\E\\s*1\\.2\\.1-SNAPSHOT\\s*\\Q</version>\\E" );
+    Matcher m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not set new version in parent pom" );
+        return false;
+    }
+    Pattern propertyPattern = Pattern.compile( "\\Q<myProperty1>\\E\\s*1\\.2\\.1-SNAPSHOT\\s*\\Q</myProperty1>\\E" );
+    if ( !propertyPattern.matcher( buf.toString() ).find() )
+    {
+        System.out.println( "Did not set property 'myProperty1' to new version in parent pom" );
+        return false;
+    }
+
+
+
+    file = new File( basedir, "module-a1/pom.xml" );
+
+    in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    buf = new StringBuilder();
+    line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.1-SNAPSHOT\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent version in module-a1/pom" );
+        return false;
+    }
+    p = Pattern.compile( "\\Q</parent>\\E.*\\Q<version>\\E\\s*2\\.0\\.7-SNAPSHOT\\s*\\Q</version>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did update child version in module-a1/pom" );
+        return false;
+    }
+
+    file = new File( basedir, "module-a2/pom.xml" );
+
+    in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    buf = new StringBuilder();
+    line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.1-SNAPSHOT\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent version in module-a2/pom" );
+        return false;
+    }
+    p = Pattern.compile( "\\Q</parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.1-SNAPSHOT\\s*\\Q</version>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update child version in module-a2/pom" );
+        return false;
+    }
+    if ( !propertyPattern.matcher( buf.toString() ).find() )
+    {
+        System.out.println( "Did not set property 'myProperty1' to new version in module-a2/pom" );
+        return false;
+    }
+
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-set-011/invoker.properties
+++ b/src/it/it-set-011/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -DnewVersion=1.2.1 -Dversion.versions-maven-plugin=${project.version}
+invoker.nonRecursive=true
+invoker.buildResult=success

--- a/src/it/it-set-011/module-a1/pom.xml
+++ b/src/it/it-set-011/module-a1/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>project-a</artifactId>
+    <version>1.2.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a1</artifactId>
+  <packaging>pom</packaging>
+  <version>2.0.7-SNAPSHOT</version>
+
+</project>

--- a/src/it/it-set-011/module-a2/pom.xml
+++ b/src/it/it-set-011/module-a2/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>project-a</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a2</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0</version>
+
+  <properties>
+    <myProperty2>1.2.0</myProperty2>
+  </properties>
+
+</project>

--- a/src/it/it-set-011/pom.xml
+++ b/src/it/it-set-011/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>project-a</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0</version>
+  <name>mversions-71</name>
+
+  <description>
+    invoking versions:set on root module should not update child module versions
+    unless they are the same as the parent old version
+  </description>
+
+  <modules>
+    <module>module-a1</module>
+    <module>module-a2</module>
+  </modules>
+
+  <properties>
+    <myProperty1>1.2.0</myProperty1>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.2-beta-2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ear-plugin</artifactId>
+          <version>2.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ejb-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-rar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.0-beta-7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.0.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.1-alpha-1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${version.versions-maven-plugin}</version>
+        <configuration>
+          <setProperties>
+            <setProperty>myProperty1</setProperty>
+            <setProperty>myProperty2</setProperty>
+          </setProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-set-011/verify.bsh
+++ b/src/it/it-set-011/verify.bsh
@@ -1,0 +1,102 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+import java.util.regex.*;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+
+    BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    StringBuilder buf = new StringBuilder();
+    String line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    Pattern p = Pattern.compile( "\\Q<version>\\E\\s*1\\.2\\.1\\s*\\Q</version>\\E" );
+    Matcher m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not set new version in parent pom" );
+        return false;
+    }
+    Pattern propertyPattern = Pattern.compile( "\\Q<myProperty1>\\E\\s*1\\.2\\.1\\s*\\Q</myProperty1>\\E" );
+    if ( !propertyPattern.matcher( buf.toString() ).find() )
+    {
+        System.out.println( "Did not set property 'myProperty1' to new version in parent pom" );
+        return false;
+    }
+
+
+
+    file = new File( basedir, "module-a1/pom.xml" );
+
+    in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    buf = new StringBuilder();
+    line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.1\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent version in module-a1/pom" );
+        return false;
+    }
+    p = Pattern.compile( "\\Q</parent>\\E.*\\Q<version>\\E\\s*2\\.0\\.7-SNAPSHOT\\s*\\Q</version>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did update child version in module-a1/pom" );
+        return false;
+    }
+
+    file = new File( basedir, "module-a2/pom.xml" );
+
+    in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    buf = new StringBuilder();
+    line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.1\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent version in module-a2/pom" );
+        return false;
+    }
+    p = Pattern.compile( "\\Q</parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.1\\s*\\Q</version>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update child version in module-a2/pom" );
+        return false;
+    }
+    propertyPattern = Pattern.compile( "\\Q<myProperty2>\\E\\s*1\\.2\\.1\\s*\\Q</myProperty2>\\E" );
+    if ( !propertyPattern.matcher( buf.toString() ).find() )
+    {
+        System.out.println( "Did not set property 'myProperty2' to new version in module-a2/pom" );
+        return false;
+    }
+
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-set-012/invoker.properties
+++ b/src/it/it-set-012/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -DnewVersion=1.2.3 -Dversion.versions-maven-plugin=${project.version}
+invoker.nonRecursive=true
+invoker.buildResult=success

--- a/src/it/it-set-012/module-a1/pom.xml
+++ b/src/it/it-set-012/module-a1/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>project-a</artifactId>
+    <version>1.2.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a1</artifactId>
+  <packaging>pom</packaging>
+  <version>2.0.7-SNAPSHOT</version>
+
+</project>

--- a/src/it/it-set-012/module-a2/pom.xml
+++ b/src/it/it-set-012/module-a2/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>project-a</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a2</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0</version>
+
+  <profiles>
+    <profile>
+      <id>myProfile</id>
+      <properties>
+        <myProperty1>1.2.0</myProperty1>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/src/it/it-set-012/pom.xml
+++ b/src/it/it-set-012/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>project-a</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0</version>
+  <name>mversions-71</name>
+
+  <description>
+    invoking versions:set on root module should not update child module versions
+    unless they are the same as the parent old version
+  </description>
+
+  <modules>
+    <module>module-a1</module>
+    <module>module-a2</module>
+  </modules>
+
+  <properties>
+    <myProperty1>1.2.0</myProperty1>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.2-beta-2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ear-plugin</artifactId>
+          <version>2.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ejb-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-rar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.0-beta-7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.0.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.1-alpha-1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${version.versions-maven-plugin}</version>
+        <configuration>
+          <setProperties>
+            <setProperty>myProfile/myProperty1</setProperty>
+          </setProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-set-012/verify.bsh
+++ b/src/it/it-set-012/verify.bsh
@@ -1,0 +1,102 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+import java.util.regex.*;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+
+    BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    StringBuilder buf = new StringBuilder();
+    String line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    Pattern p = Pattern.compile( "\\Q<version>\\E\\s*1\\.2\\.3\\s*\\Q</version>\\E" );
+    Matcher m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not set new version in parent pom" );
+        return false;
+    }
+    Pattern propertyPattern = Pattern.compile( "\\Q<myProperty1>\\E\\s*1\\.2\\.0\\s*\\Q</myProperty1>\\E" );
+    if ( !propertyPattern.matcher( buf.toString() ).find() )
+    {
+        System.out.println( "Did set property 'myProperty1' to new version in parent pom, although should not" );
+        return false;
+    }
+
+
+
+    file = new File( basedir, "module-a1/pom.xml" );
+
+    in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    buf = new StringBuilder();
+    line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.3\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent version in module-a1/pom" );
+        return false;
+    }
+    p = Pattern.compile( "\\Q</parent>\\E.*\\Q<version>\\E\\s*2\\.0\\.7-SNAPSHOT\\s*\\Q</version>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did update child version in module-a1/pom" );
+        return false;
+    }
+
+    file = new File( basedir, "module-a2/pom.xml" );
+
+    in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    buf = new StringBuilder();
+    line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.3\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent version in module-a2/pom" );
+        return false;
+    }
+    p = Pattern.compile( "\\Q</parent>\\E.*\\Q<version>\\E\\s*1\\.2\\.3\\s*\\Q</version>\\E" );
+    m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update child version in module-a2/pom" );
+        return false;
+    }
+    propertyPattern = Pattern.compile( "\\Q<myProperty1>\\E\\s*1\\.2\\.3\\s*\\Q</myProperty1>\\E" );
+    if ( !propertyPattern.matcher( buf.toString() ).find() )
+    {
+        System.out.println( "Did not set property 'myProperty1' to new version in module-a2/pom" );
+        return false;
+    }
+
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/set/PropertyPattern.java
+++ b/src/main/java/org/codehaus/mojo/versions/set/PropertyPattern.java
@@ -1,0 +1,217 @@
+package org.codehaus.mojo.versions.set;
+
+import java.util.regex.Pattern;
+
+import org.codehaus.mojo.versions.utils.RegexUtils;
+
+/**
+ * A facility to define which properties in which {@link PropertyScope}s should be changed.
+ * <p>
+ * Conceptually, the property patterns consist of two parts:
+ * <ol>
+ * <li>A {@link PropertyScopePattern} and
+ * <li>A property name pattern.
+ * </ol>
+ * <p>
+ * {@link PropertyScopePattern} depicts a the scope in which the given property should be changed. There are just two
+ * places in the hierarchy of pom.xml elements, where {@code <properties>} can be located: (i) directly under
+ * {@code <project>} or (ii) under a {@code <profile>}. This gives three possible kinds of
+ * {@link PropertyScopePattern}s:
+ * <ol>
+ * <li>In-profile to match only properties under a {@code <profile>}
+ * <li>Profile-less to match only properties directly under {@code <project>}
+ * <li>Match-all to match both above kinds.
+ * </ol>
+ * <p>
+ * The property name pattern is there for selecting which specific property or properties should be changed.
+ * <p>
+ * Property patterns are defined using a string notation. Such strings can be passed to
+ * {@link PropertyPattern#of(String)} to parse them to {@link PropertyPattern} objects.
+ * <h2>Property patterns string notation examples:</h2>
+ * <ul>
+ * <li>{@code myProperty} matches property called {@code myProperty} located directly under {@code <project>} or under
+ * any arbitrary {@code <profile>}
+ * <li>{@code /myProfileLessProperty} matches property called {@code myProfileLessProperty} located only directly under
+ * {@code <project>}. Does not match any property occurrence under any {@code <profile>}.
+ * <li>{@code myProfile/myProperty} matches property called {@code myProperty} only if it is located under a
+ * {@code <profile>} having {@code <id>myProfile</id>}. Does not match any property occurrence directly under
+ * {@code <project>}.
+ * <li><code>myProfilePrefix&ast;/myPropertyPrefix*</code> matches all properties starting with {@code myPropertyPrefix}
+ * as long as they are located under a {@code <profile>} whose {@code id} starts with {@code myProfilePrefix}.
+ * <li><code>&ast;/myPropertyPrefix*</code> matches all properties starting with {@code myPropertyPrefix} as long as
+ * they are located under any {@code <profile>}. Does not match any property occurrence directly under
+ * {@code <project>}.
+ * </ul>
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class PropertyPattern
+{
+    /**
+     * A selector of property scopes.
+     */
+    private static abstract class PropertyScopePattern
+    {
+        private static PropertyScopePattern ANY = new PropertyScopePattern()
+        {
+            @Override
+            public boolean matches( PropertyScope propertyScope )
+            {
+                return true;
+            }
+        };
+
+        private static PropertyScopePattern PROFILE_LESS = new PropertyScopePattern()
+        {
+            @Override
+            public boolean matches( PropertyScope propertyScope )
+            {
+                return propertyScope.isProfileLess();
+            }
+        };
+
+        /**
+         * @return the {@link #ANY} singleton that matches all possible {@link PropertyScope}s
+         */
+        public static PropertyScopePattern any()
+        {
+            return ANY;
+        }
+
+        public static PropertyScopePattern ofProfile( final Pattern profileNamePattern )
+        {
+            return new PropertyScopePattern()
+            {
+
+                @Override
+                public boolean matches( PropertyScope propertyScope )
+                {
+                    return !propertyScope.isProfileLess()
+                        && profileNamePattern.matcher( propertyScope.getProfileId() ).matches();
+                }
+            };
+        }
+
+        /**
+         * @return the {@link #PROFILE_LESS} singleton that matches only those {@link PropertyScope}s whose
+         *         {@link PropertyScope#isProfileLess()} returns {@code true}
+         */
+        public static PropertyScopePattern profileLess()
+        {
+            return PROFILE_LESS;
+        }
+
+        /**
+         * @param propertyScope a {@link PropertyScope} to matchg against this {@link PropertyScopePattern}
+         * @return {@code true} if the given {@code propertyScope} matches this {@link PropertyScopePattern} or
+         *         {@code false} otherwise
+         */
+        public abstract boolean matches( PropertyScope propertyScope );
+    }
+
+    /** {@value DELIMITER} constant used to separate the scope from the property name */
+    public static final char DELIMITER = '/';
+
+    /**
+     * Parses the given {@code rawPropertyPattern} into a {@link PropertyPattern}.
+     *
+     * @param rawPropertyPattern a string such as {@code "myProperty"}, {@code "/myProfileLessProperty"},
+     *            {@code "myProfile/myProperty"}, <code>"myProfilePrefix&ast;/myPropertyPrefix*"</code>, etc.
+     * @return a new {@link PropertyPattern}
+     */
+    public static PropertyPattern of( String rawPropertyPattern )
+    {
+        if ( rawPropertyPattern == null )
+        {
+            throw new IllegalArgumentException( "Cannot parse a null rawPropertyPattern" );
+        }
+        int colonPosition = rawPropertyPattern.indexOf( DELIMITER );
+        if ( colonPosition == rawPropertyPattern.length() - 1 )
+        {
+            throw new IllegalArgumentException( PropertyPattern.class.getName() + " must not end with " + DELIMITER );
+        }
+        else if ( colonPosition == 0 )
+        {
+            /* "/myProperty" - the special profile-less property context */
+            final Pattern namePattern =
+                Pattern.compile( RegexUtils.convertWildcardsToRegex( rawPropertyPattern.substring( colonPosition + 1 ),
+                                                                     true ) );
+            return new PropertyPattern( rawPropertyPattern, PropertyScopePattern.profileLess(), namePattern );
+        }
+        else if ( colonPosition > 0 )
+        {
+            /* "myProfile/myProperty" - non-empty profile name - this is going to be a in-profile matcher */
+            final Pattern profilePattern =
+                Pattern.compile( RegexUtils.convertWildcardsToRegex( rawPropertyPattern.substring( 0, colonPosition ),
+                                                                     true ) );
+            final Pattern namePattern =
+                Pattern.compile( RegexUtils.convertWildcardsToRegex( rawPropertyPattern.substring( colonPosition + 1 ),
+                                                                     true ) );
+            return new PropertyPattern( rawPropertyPattern, PropertyScopePattern.ofProfile( profilePattern ),
+                                        namePattern );
+        }
+        else
+        {
+            /* "myProperty" - there is no collon - we will match all contexts - i.e. both profile-less and in-profile */
+            final Pattern namePattern =
+                Pattern.compile( RegexUtils.convertWildcardsToRegex( rawPropertyPattern, true ) );
+            return new PropertyPattern( rawPropertyPattern, PropertyScopePattern.any(), namePattern );
+        }
+    }
+
+    /** A regular expression for selecting property names */
+    private final Pattern namePattern;
+
+    /** A selector of {@link PropertyScope}s */
+    private final PropertyScopePattern propertyScopePattern;
+
+    /** The string representation we parsed from; cannot be {@code null} */
+    private final String rawPattern;
+
+    private PropertyPattern( String rawPattern, PropertyScopePattern propertyScopePattern, Pattern namePattern )
+    {
+        super();
+        this.rawPattern = rawPattern;
+        this.propertyScopePattern = propertyScopePattern;
+        this.namePattern = namePattern;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+            return true;
+        if ( obj == null )
+            return false;
+        if ( getClass() != obj.getClass() )
+            return false;
+        return rawPattern.equals( ((PropertyPattern) obj).rawPattern );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return rawPattern.hashCode();
+    }
+
+    /**
+     * @param propertyScope a property scope in which the property of the given name is located
+     * @param propertyName the property name
+     * @return {@code true} if the given {@link PropertyScope} matches {@link #propertyScopePattern} and given
+     *         {@code propertyName} matches {@link #namePattern}; or {@code false} otherwise
+     */
+    public boolean matches( PropertyScope propertyScope, String propertyName )
+    {
+        return propertyScopePattern.matches( propertyScope ) && namePattern.matcher( propertyName ).matches();
+    }
+
+    /**
+     * @return {@link #rawPattern}
+     */
+    @Override
+    public String toString()
+    {
+        return rawPattern;
+    }
+
+}

--- a/src/main/java/org/codehaus/mojo/versions/set/PropertyScope.java
+++ b/src/main/java/org/codehaus/mojo/versions/set/PropertyScope.java
@@ -1,0 +1,69 @@
+package org.codehaus.mojo.versions.set;
+
+/**
+ * A location of a property in the hierarchy of pom.xml elements. There are two kinds of property scopes:
+ * <ol>
+ * <li>Profile-less - the one at the project level, out of any profile - see {@link #profileLess()}.
+ * <li>In-profile - under a profile - see {@link #ofProfile(String)}
+ * </ol>
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class PropertyScope
+{
+    /** A singleton that has a {@code null} {@link #profileId} set */
+    private static final PropertyScope PROFILE_LESS = new PropertyScope( null );
+
+    /**
+     * @param profileId the id of the profile the returned scope is defined for
+     * @return a new {@link PropertyScope} ranging over a profile with the given {@code profileId}
+     */
+    public static PropertyScope ofProfile( String profileId )
+    {
+        return new PropertyScope( profileId );
+    }
+
+    /**
+     * @return the {@link #PROFILE_LESS} singleton that has a {@code null} {@link #profileId} set
+     */
+    public static PropertyScope profileLess()
+    {
+        return PROFILE_LESS;
+    }
+
+    /** The profile id this {@link PropertyScope} ranges over, possibly {@code null} */
+    private final String profileId;
+
+    private PropertyScope( String profileId )
+    {
+        super();
+        this.profileId = profileId;
+    }
+
+    /**
+     * {@link #isProfileLess()} should always be called before {@link #getProfileId()} to avoid
+     * {@link IllegalStateException}.
+     *
+     * @return {@link #profileId} - the profile id this {@link PropertyScope} ranges over
+     * @throws IllegalStateException if {@link #profileId} is {@code null}
+     */
+    public String getProfileId()
+    {
+        if ( profileId == null )
+        {
+            throw new IllegalStateException( "You should call " + PropertyScope.class.getName()
+                + ".getProfileId() only if isProfileLess() returns true." );
+        }
+        return profileId;
+    }
+
+    /**
+     * @return {@code true} if this {@link PropertyScope}'s {@link #profileId} is {@code null} - i.e. if this
+     *         {@link PropertyScope} does not range over any profile
+     */
+    public boolean isProfileLess()
+    {
+        return profileId == null;
+    }
+
+}

--- a/src/test/java/org/codehaus/mojo/versions/set/PropertyPatternTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/set/PropertyPatternTest.java
@@ -1,0 +1,62 @@
+package org.codehaus.mojo.versions.set;
+
+import org.junit.Assert;
+
+import junit.framework.TestCase;
+
+public class PropertyPatternTest
+    extends TestCase
+{
+    public void testAnyLiteral()
+    {
+        PropertyPattern p = PropertyPattern.of( "myProperty" );
+        Assert.assertTrue( p.toString() + " should match profile-less myProperty",
+                           p.matches( PropertyScope.profileLess(), "myProperty" ) );
+        Assert.assertTrue( p.toString() + " should match myProperty under anyProfile",
+                           p.matches( PropertyScope.ofProfile( "anyProfile" ), "myProperty" ) );
+    }
+
+    public void testProfileLessLiteral()
+    {
+        PropertyPattern p = PropertyPattern.of( "/myProperty" );
+        Assert.assertTrue( p.toString() + " should match profile-less myProperty",
+                           p.matches( PropertyScope.profileLess(), "myProperty" ) );
+        Assert.assertFalse( p.toString() + " should not match myProperty under anyProfile",
+                           p.matches( PropertyScope.ofProfile( "anyProfile" ), "myProperty" ) );
+    }
+
+    public void testInProfileLiteral()
+    {
+        PropertyPattern p = PropertyPattern.of( "myProfile/myProperty" );
+        Assert.assertFalse( p.toString() + " should not match profile-less myProperty",
+                           p.matches( PropertyScope.profileLess(), "myProperty" ) );
+        Assert.assertTrue( p.toString() + " should match myProperty under myProfile",
+                           p.matches( PropertyScope.ofProfile( "myProfile" ), "myProperty" ) );
+        Assert.assertFalse( p.toString() + " should not match myProperty under anyProfile",
+                            p.matches( PropertyScope.ofProfile( "anyProfile" ), "myProperty" ) );
+    }
+
+    public void testAnyPattern()
+    {
+        PropertyPattern p = PropertyPattern.of( "myProperty*" );
+        Assert.assertTrue( p.toString() + " should match profile-less myProperty",
+                           p.matches( PropertyScope.profileLess(), "myProperty" ) );
+        Assert.assertTrue( p.toString() + " should match profile-less myProperty42",
+                           p.matches( PropertyScope.profileLess(), "myProperty42" ) );
+        Assert.assertTrue( p.toString() + " should match myProperty under anyProfile",
+                           p.matches( PropertyScope.ofProfile( "anyProfile" ), "myProperty" ) );
+        Assert.assertTrue( p.toString() + " should match myProperty42 under anyProfile",
+                           p.matches( PropertyScope.ofProfile( "anyProfile" ), "myProperty42" ) );
+    }
+
+    public void testProfilePattern()
+    {
+        PropertyPattern p = PropertyPattern.of( "*/myProperty" );
+        Assert.assertFalse( p.toString() + " should not match profile-less myProperty",
+                           p.matches( PropertyScope.profileLess(), "myProperty" ) );
+        Assert.assertTrue( p.toString() + " should match myProperty under myProfile",
+                           p.matches( PropertyScope.ofProfile( "myProfile" ), "myProperty" ) );
+        Assert.assertTrue( p.toString() + " should not match myProperty under anyProfile",
+                            p.matches( PropertyScope.ofProfile( "anyProfile" ), "myProperty" ) );
+    }
+}


### PR DESCRIPTION
@khmarbaise could you please review?

This is primarily motivated by projects like [1] which manage their own modules
using a version property. In the current versions plugin there is no
simple way to set this property by a single versions:set invocation. 

After this change it will be possible to configure the versions-maven-plugin to set any desired property  [2] to the `newVersion` automagically, e.g. when releasing.

[1] https://github.com/pietermartin/sqlg/blob/master/pom.xml#L191-L205 note that `sqlg.version` is supposed to be kept in sync with `project.version`  https://github.com/pietermartin/sqlg/blob/master/pom.xml#L34 https://github.com/pietermartin/sqlg/blob/master/pom.xml#L16

[2] https://github.com/mojohaus/versions-maven-plugin/commit/bdee9e04c777e50f76c1ecba359ab9106850e1a1#diff-13791dad6080eb3527564192fbbc5f5eR113