### PR TITLE
Fix for #134: Goal: use-releases doesn't processes imported POMs in dependencyManagement

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -88,6 +88,7 @@ public class UseReleasesMojo
         {
             if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
             {
+                useReleases( pom, PomHelper.readImportedPOMsFromDependencyManagementSection(pom) );
                 useReleases( pom, getProject().getDependencyManagement().getDependencies() );
             }
             if ( isProcessingDependencies() )

--- a/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -52,6 +52,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -1624,5 +1625,78 @@ public class PomHelper
     public static String getGAV( Model model )
     {
         return getGroupId( model ) + ":" + getArtifactId( model ) + ":" + getVersion( model );
+    }
+
+    /**
+     * Reads imported POMs from the dependency management section.
+     *
+     * @param pom
+     * @return a non-null list of {@link Dependency} for each imported POM
+     * @throws XMLStreamException
+     * @see <a href="https://github.com/mojohaus/versions-maven-plugin/issues/134">bug #134</a>
+     * @since 2.4
+     */
+    public static List<Dependency> readImportedPOMsFromDependencyManagementSection( ModifiedPomXMLEventReader pom )
+        throws XMLStreamException
+    {
+        List<Dependency> importedPOMs = new ArrayList<Dependency>();
+        Stack<String> stack = new Stack<String>();
+
+        String groupIdElement = "groupId";
+        String artifactIdElement = "artifactId";
+        String versionElement = "version";
+        String typeElement = "type";
+        String scopeElement = "scope";
+        Set<String> recognizedElements =
+            new HashSet<String>( Arrays.asList( groupIdElement, artifactIdElement, versionElement, typeElement,
+                                                scopeElement ) );
+        Map<String, String> depData = new HashMap<String, String>();
+
+        pom.rewind();
+
+        String depMgmtDependencyPath = "/project/dependencyManagement/dependencies/dependency";
+
+        while ( pom.hasNext() )
+        {
+            XMLEvent event = pom.nextEvent();
+
+            if ( event.isStartElement() )
+            {
+                final String elementName = event.asStartElement().getName().getLocalPart();
+                String parent = "";
+                if ( !stack.isEmpty() )
+                {
+                    parent = stack.peek();
+                }
+                String currentPath = parent + "/" + elementName;
+                stack.push( currentPath );
+
+                if ( currentPath.startsWith( depMgmtDependencyPath ) && recognizedElements.contains( elementName ) )
+                {
+                    final String elementText = pom.getElementText().trim();
+                    depData.put( elementName, elementText );
+                    stack.pop();
+                }
+            }
+            if ( event.isEndElement() )
+            {
+                String path = stack.pop();
+                if ( depMgmtDependencyPath.equals( path ) )
+                {
+                    if ( "pom".equals( depData.get( typeElement ) ) && "import".equals( depData.get( scopeElement ) ) )
+                    {
+                        Dependency dependency = new Dependency();
+                        dependency.setGroupId( depData.get( groupIdElement ) );
+                        dependency.setArtifactId( depData.get( artifactIdElement ) );
+                        dependency.setVersion( depData.get( versionElement ) );
+                        dependency.setType( depData.get( typeElement ) );
+                        dependency.setScope( depData.get( scopeElement ) );
+                        importedPOMs.add( dependency );
+                    }
+                    depData.clear();
+                }
+            }
+        }
+        return importedPOMs;
     }
 }

--- a/src/test/resources/org/codehaus/mojo/versions/api/PomHelperTest.dependencyManagementBOMs.pom.xml
+++ b/src/test/resources/org/codehaus/mojo/versions/api/PomHelperTest.dependencyManagementBOMs.pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.myorg</groupId>
+        <artifactId>myorg-parent</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>bug-79</artifactId>
+    <packaging>jar</packaging>
+    <name>extracts BOMs from dependency management</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.group1</groupId>
+                <artifactId>artifact-pom</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.group1</groupId>
+                <artifactId>artifact-jar</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <type>jar</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.group1</groupId>
+                <artifactId>artifact-pom-standard</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>


### PR DESCRIPTION
+ added PomHelper.readImportedPOMsFromDependencyManagementSection in order to read imported POMs from raw pom.xml
* UseReleases process imported POMs when processing dependencyManagement
* fixed spelling mistake in javadoc for PomHelperTest