### PR TITLE
Fixed #153: 'processParent' not working for use-releases goal

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -237,6 +237,22 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
         return artifact;
     }
 
+    protected String toString( MavenProject project ) {
+        StringBuilder buf = new StringBuilder();
+
+        buf.append( project.getGroupId() );
+        buf.append( ':' );
+        buf.append( project.getArtifactId() );
+
+        if ( project.getVersion() != null && project.getVersion().length() > 0 )
+        {
+            buf.append( ":" );
+            buf.append( project.getVersion() );
+        }
+
+        return buf.toString();
+    }
+
     protected String toString( Dependency d )
     {
         StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
The documentation listed here makes it seem like this flag should process the parent section of the POM (and remove -SNAPSHOT), but that functionality wasn't there. 