### PR TITLE
Allow nextSnapshot from a non-snapshot version

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -228,12 +228,10 @@ public class SetMojo
 
         if ( !removeSnapshot && nextSnapshot )
         {
-            boolean havingSnapshot = false;
             String version = getVersion();
             String versionWithoutSnapshot = version;
             if ( version.endsWith( SNAPSHOT ) )
             {
-                havingSnapshot = true;
                 versionWithoutSnapshot = version.substring( 0, version.indexOf( SNAPSHOT ) );
             }
             LinkedList<String> numbers = new LinkedList<String>();
@@ -251,10 +249,7 @@ public class SetMojo
             int lastNumber = Integer.parseInt( numbers.removeLast() );
             numbers.addLast( String.valueOf( lastNumber + 1 ) );
             String nextVersion = StringUtils.join( numbers.toArray( new String[0] ), "." );
-            if ( havingSnapshot )
-            {
-                newVersion = nextVersion + "-SNAPSHOT";
-            }
+            newVersion = nextVersion + "-SNAPSHOT";
             getLog().info( "SNAPSHOT found.  BEFORE " + version + "  --> AFTER: " + newVersion );
         }
 


### PR DESCRIPTION
Hi,
There's a bug in
```java
mvn versions:set -DnextSnapshot
```
that prevents it from automatically generating the next snapshot if the current version isn't already a SNAPSHOT. This makes it relatively difficult to move to the next snapshot after we've deployed a release.

**Before**
![screenshot from 2017-09-20 00-02-59](https://user-images.githubusercontent.com/1888108/30626456-0ad95bc4-9d98-11e7-8a89-c20ae12a58d0.png)
**After**
![screenshot from 2017-09-20 00-01-26](https://user-images.githubusercontent.com/1888108/30626458-13cbcc76-9d98-11e7-9439-257688ad6bc8.png)

