### PR TITLE
Fixed 195

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -795,21 +795,8 @@ public class DisplayPluginUpdatesMojo
 
     private String getRequiredMavenVersion( MavenProject mavenProject, String defaultValue )
     {
-        ArtifactVersion requiredMavenVersion = null;
-        while ( mavenProject != null )
-        {
-            final Prerequisites prerequisites = mavenProject.getPrerequisites();
-            final String mavenVersion = prerequisites == null ? null : prerequisites.getMaven();
-            if ( mavenVersion != null )
-            {
-                final ArtifactVersion v = new DefaultArtifactVersion( mavenVersion );
-                if ( requiredMavenVersion == null || requiredMavenVersion.compareTo( v ) < 0 )
-                {
-                    requiredMavenVersion = v;
-                }
-            }
-            mavenProject = mavenProject.getParent();
-        }
+        ArtifactVersion requiredMavenVersion = new RequiredMavenVersionFinder(mavenProject).find();
+
         return requiredMavenVersion == null ? defaultValue : requiredMavenVersion.toString();
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/RequiredMavenVersionFinder.java
+++ b/src/main/java/org/codehaus/mojo/versions/RequiredMavenVersionFinder.java
@@ -1,0 +1,143 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.Prerequisites;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.util.List;
+
+/**
+ * Finds the minimum Maven version required by a Maven project.
+ * Checks for the existence of both the prerequisites.maven property and for maven-enforcer-plugin:enforce goal.
+ * Returns null if no minimum version is found.
+ * Checks project and it's parents recursively.
+ *
+ * Pros: works with Maven 3.5.0 which throws a warning if prerequisites.maven is set for a non Maven-Plugin project.
+ * Cons: tightly coupled with the maven-enforcer-plugin and the Xpp3Dom configuration tag.
+ */
+class RequiredMavenVersionFinder {
+
+    private final MavenProject mavenProject;
+
+    RequiredMavenVersionFinder(MavenProject mavenProject) {
+        this.mavenProject = mavenProject;
+    }
+
+    ArtifactVersion find() {
+        ArtifactVersion childMavenVersion = getHighestArtifactVersion(getPrerequisitesMavenVersion(), getEnforcerMavenVersion());
+
+        if (!mavenProject.hasParent()) {
+            return childMavenVersion;
+        }
+
+        ArtifactVersion parentMavenVersion = new RequiredMavenVersionFinder(mavenProject.getParent()).find();
+
+        return getHighestArtifactVersion(childMavenVersion, parentMavenVersion);
+    }
+
+    private ArtifactVersion getPrerequisitesMavenVersion() {
+        Prerequisites prerequisites = mavenProject.getPrerequisites();
+        if (null == prerequisites) {
+            return null;
+        }
+
+        String prerequisitesMavenValue = prerequisites.getMaven();
+        if (null == prerequisitesMavenValue) {
+            return null;
+        }
+
+        return new DefaultArtifactVersion(prerequisitesMavenValue);
+    }
+
+    private ArtifactVersion getEnforcerMavenVersion() {
+        List<Plugin> buildPlugins = mavenProject.getBuildPlugins();
+        if (null == buildPlugins) {
+            return null;
+        }
+
+        Plugin mavenEnforcerPlugin = getMavenEnforcerPlugin(buildPlugins);
+        if (null == mavenEnforcerPlugin) {
+            return null;
+        }
+
+        List<PluginExecution> pluginExecutions = mavenEnforcerPlugin.getExecutions();
+        if (null == pluginExecutions) {
+            return null;
+        }
+
+        PluginExecution pluginExecutionWithEnforceGoal = getPluginExecutionWithEnforceGoal(pluginExecutions);
+        if (null == pluginExecutionWithEnforceGoal) {
+            return null;
+        }
+
+        Xpp3Dom configurationTag = (Xpp3Dom) pluginExecutionWithEnforceGoal.getConfiguration();
+        if (null == configurationTag) {
+            return null;
+        }
+
+        Xpp3Dom rulesTag = configurationTag.getChild("rules");
+        if (null == rulesTag) {
+            return null;
+        }
+
+        Xpp3Dom requireMavenVersionTag = rulesTag.getChild("requireMavenVersion");
+        if (null == requireMavenVersionTag) {
+            return null;
+        }
+
+        Xpp3Dom versionTag = requireMavenVersionTag.getChild("version");
+        if (null == versionTag) {
+            return null;
+        }
+
+        String versionTagValue = versionTag.getValue();
+        if (null == versionTagValue) {
+            return null;
+        }
+
+        return new DefaultArtifactVersion(versionTagValue);
+    }
+
+    private Plugin getMavenEnforcerPlugin(List<Plugin> buildPlugins) {
+        for (Plugin plugin : buildPlugins) {
+            if ("maven-enforcer-plugin".equals(plugin.getArtifactId())) {
+                return plugin;
+            }
+        }
+        return null;
+    }
+
+    private PluginExecution getPluginExecutionWithEnforceGoal(List<PluginExecution> executions) {
+        for (PluginExecution pluginExecution : executions) {
+            List<String> goals = pluginExecution.getGoals();
+            if (goals != null && goals.contains("enforce")) {
+                return pluginExecution;
+            }
+        }
+        return null;
+    }
+
+    private ArtifactVersion getHighestArtifactVersion(ArtifactVersion firstMavenVersion, ArtifactVersion secondMavenVersion) {
+        if (null == firstMavenVersion && null == secondMavenVersion) {
+            return null;
+        }
+
+        if (null == firstMavenVersion) {
+            return secondMavenVersion;
+        }
+
+        if (null == secondMavenVersion) {
+            return firstMavenVersion;
+        }
+
+        if (firstMavenVersion.compareTo(secondMavenVersion) < 0) {
+            return secondMavenVersion;
+        }
+
+        return firstMavenVersion;
+    }
+}

--- a/src/test/java/org/codehaus/mojo/versions/RequiredMavenVersionFinderTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/RequiredMavenVersionFinderTest.java
@@ -1,0 +1,312 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.Prerequisites;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for RequiredMavenVersionFinder.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RequiredMavenVersionFinderTest {
+
+    @Mock
+    private MavenProject mavenProject;
+    @Mock
+    private Prerequisites prerequisites;
+    @Mock
+    private Plugin nonEnforcerPlugin;
+    @Mock
+    private Plugin enforcerPlugin;
+    @Mock
+    private PluginExecution pluginExecution;
+    @Mock
+    private Xpp3Dom configurationTag;
+    @Mock
+    private Xpp3Dom rulesTag;
+    @Mock
+    private Xpp3Dom requireMavenVersionTag;
+    @Mock
+    private Xpp3Dom versionTag;
+    @Mock
+    private MavenProject parentMavenProject;
+    @Mock
+    private Prerequisites parentPrerequisites;
+
+    @Before
+    public void setup() {
+        when(mavenProject.getPrerequisites()).thenReturn(null);
+        when(mavenProject.getBuildPlugins()).thenReturn(null);
+        when(mavenProject.hasParent()).thenReturn(false);
+        when(prerequisites.getMaven()).thenReturn(null);
+        when(nonEnforcerPlugin.getArtifactId()).thenReturn(null);
+        when(enforcerPlugin.getArtifactId()).thenReturn("maven-enforcer-plugin");
+        when(enforcerPlugin.getExecutions()).thenReturn(null);
+        when(pluginExecution.getGoals()).thenReturn(null);
+        when(parentMavenProject.getPrerequisites()).thenReturn(null);
+        when(parentMavenProject.getBuildPlugins()).thenReturn(null);
+        when(parentMavenProject.hasParent()).thenReturn(false);
+        when(parentPrerequisites.getMaven()).thenReturn(null);
+    }
+
+    @Test
+    public void findReturnsNullWhenPrerequisitesAreNullAndBuildPluginListIsNull() {
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenPrerequisitesMavenVersionIsNull() {
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNotNullWhenPrerequisitesMavenVersionIsNotNull() {
+        String mavenVersion = "1";
+        DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(mavenVersion);
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        when(prerequisites.getMaven()).thenReturn(mavenVersion);
+        assertEquals(artifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenBuildPluginsListDoesNotContainEnforcerPlugin() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(nonEnforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenEnforcerExecutionsIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenExecutionsListIsEmpty() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenExecutionGoalsListIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenPopulatedExecutionsListDoNotContainEnforcerExecution() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenEnforceGoalConfigurationIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        goals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(null);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenRulesChildIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        goals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(null);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenRequiredMavenVersionChildIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        goals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(null);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenVersionChildIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        goals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(requireMavenVersionTag);
+        when(requireMavenVersionTag.getChild("version")).thenReturn(null);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenVersionTagValueIsNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        goals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(requireMavenVersionTag);
+        when(requireMavenVersionTag.getChild("version")).thenReturn(versionTag);
+        when(versionTag.getValue()).thenReturn(null);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsValueWhenVersionTagValueIsNotNull() {
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        goals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(requireMavenVersionTag);
+        when(requireMavenVersionTag.getChild("version")).thenReturn(versionTag);
+        String mavenVersion = "1";
+        when(versionTag.getValue()).thenReturn(mavenVersion);
+        DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(mavenVersion);
+        assertEquals(artifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsNullWhenChildWithoutVersionAndParentWithoutVersion() {
+        when(mavenProject.hasParent()).thenReturn(true);
+        when(mavenProject.getParent()).thenReturn(parentMavenProject);
+        assertNull(new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsChildVersionWhenChildWithVersionAndParentWithoutVersion() {
+        when(mavenProject.hasParent()).thenReturn(true);
+        when(mavenProject.getParent()).thenReturn(parentMavenProject);
+        String childMavenVersion = "1";
+        DefaultArtifactVersion childArtifactVersion = new DefaultArtifactVersion(childMavenVersion);
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        when(prerequisites.getMaven()).thenReturn(childMavenVersion);
+        assertEquals(childArtifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsParentVersionWhenChildWithoutVersionAndParentWithVersion() {
+        when(mavenProject.hasParent()).thenReturn(true);
+        when(mavenProject.getParent()).thenReturn(parentMavenProject);
+        String parentMavenVersion = "1";
+        DefaultArtifactVersion parentArtifactVersion = new DefaultArtifactVersion(parentMavenVersion);
+        when(parentMavenProject.getPrerequisites()).thenReturn(parentPrerequisites);
+        when(parentPrerequisites.getMaven()).thenReturn(parentMavenVersion);
+        assertEquals(parentArtifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsChildVersionWhenChildWithMatchingVersionAndParentWithMatchingVersion() {
+        when(mavenProject.hasParent()).thenReturn(true);
+        when(mavenProject.getParent()).thenReturn(parentMavenProject);
+        String childMavenVersion = "1";
+        DefaultArtifactVersion childArtifactVersion = new DefaultArtifactVersion(childMavenVersion);
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        when(prerequisites.getMaven()).thenReturn(childMavenVersion);
+        String parentMavenVersion = "1";
+        when(parentMavenProject.getPrerequisites()).thenReturn(parentPrerequisites);
+        when(parentPrerequisites.getMaven()).thenReturn(parentMavenVersion);
+        assertEquals(childArtifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsChildVersionWhenChildWithHigherVersionAndParentWithLowerVersion() {
+        when(mavenProject.hasParent()).thenReturn(true);
+        when(mavenProject.getParent()).thenReturn(parentMavenProject);
+        String childMavenVersion = "2";
+        DefaultArtifactVersion childArtifactVersion = new DefaultArtifactVersion(childMavenVersion);
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        when(prerequisites.getMaven()).thenReturn(childMavenVersion);
+        String parentMavenVersion = "1";
+        when(parentMavenProject.getPrerequisites()).thenReturn(parentPrerequisites);
+        when(parentPrerequisites.getMaven()).thenReturn(parentMavenVersion);
+        assertEquals(childArtifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsParentVersionWhenChildWithLowerVersionAndParentWithHigherVersion() {
+        when(mavenProject.hasParent()).thenReturn(true);
+        when(mavenProject.getParent()).thenReturn(parentMavenProject);
+        String childMavenVersion = "1";
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        when(prerequisites.getMaven()).thenReturn(childMavenVersion);
+        String parentMavenVersion = "2";
+        DefaultArtifactVersion parentArtifactVersion = new DefaultArtifactVersion(parentMavenVersion);
+        when(parentMavenProject.getPrerequisites()).thenReturn(parentPrerequisites);
+        when(parentPrerequisites.getMaven()).thenReturn(parentMavenVersion);
+        assertEquals(parentArtifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+}


### PR DESCRIPTION
Issue 195 read enforcer or prerequisites tag.
https://github.com/mojohaus/versions-maven-plugin/issues/195
https://github.com/mojohaus/versions-maven-plugin/issues/48
https://github.com/mojohaus/versions-maven-plugin/issues/181
https://github.com/mojohaus/versions-maven-plugin/issues/210

In maven 3.5.0 the prerequisites tag is only valid for plugin type projects.
Currently the versions-maven-plugin requires the prerequisites tag to compare the minimum maven version requirements of plugins in the pom.

If you use the prerequisites tag with maven 3.5.0 you get the following warning:
`[WARNING] The project dje1990:rts:war:HEAD-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html`

If you remove the prerequisites tag (with any maven version) with the current version of versions-maven-plugin you get:
```
[WARNING] Project does not define minimum Maven version, default is: 2.0
[INFO] Plugins require minimum Maven version of: 3.0
[INFO] 
[ERROR] Project does not define required minimum version of Maven.
[ERROR] Update the pom.xml to contain maven-enforcer-plugin to
[ERROR] force the maven version which is needed to build this project.
[ERROR] See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[ERROR] Using the minimum version of Maven: 3.0
```

The versions-maven-plugin needs to be able to read the minimum maven version from both the maven-enforcer-plugin and the prerequisites tag (for plugin type projects) for a pom and all it's parent poms.


This pull request attempts to implement the above. The javadoc for the main implementation class reads:

```
/**
 * Finds the minimum Maven version required by a Maven project.
 * Checks for the existence of both the prerequisites.maven property and for maven-enforcer-plugin:enforce goal.
 * Returns null if no minimum version is found.
 * Checks project and it's parents recursively.
 *
 * Pros: works with Maven 3.5.0 which throws a warning if prerequisites.maven is set for a non Maven-Plugin project.
 * Cons: tightly coupled with the maven-enforcer-plugin and the Xpp3Dom configuration tag.
 */
class RequiredMavenVersionFinder {
```

This pull request contains the implementation and unit tests (100% coverage for the main implementation class). 
Some manual testing has also been carried out with the following result using maven 3.5.0 with the prerequisites tag removed and the maven-enforcer-plugin needing 3.5.0:
```
[INFO] --- versions-maven-plugin:2.6-SNAPSHOT:display-plugin-updates (version-checks) @ rts ---
[INFO] 
[INFO] All plugins with a version specified are using the latest versions.
[INFO] 
[INFO] All plugins have a version specified.
[INFO] 
[INFO] Project inherits minimum Maven version as: 3.5.0
[INFO] Plugins require minimum Maven version of: 3.0
[INFO] 
[INFO] No plugins require a newer version of Maven than specified by the pom.
```

Please review the change, test the implementation for your own needs, and let me know if any additional 
changes are needed.

