### PR TITLE
versions:display-dependency-updates bug in config

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -385,7 +385,10 @@ public class DisplayDependencyUpdatesMojo
                     if ( allowIncrementalUpdates )
                     {
                         result = UpdateScope.INCREMENTAL;
-                    }
+                    }else
+					{
+						result = UpdateScope.SUBINCREMENTAL;
+					} 
                 }
             }
         }

--- a/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -386,9 +386,9 @@ public class DisplayDependencyUpdatesMojo
                     {
                         result = UpdateScope.INCREMENTAL;
                     }else
-					{
-						result = UpdateScope.SUBINCREMENTAL;
-					} 
+                    {
+                        result = UpdateScope.SUBINCREMENTAL;
+                    } 
                 }
             }
         }


### PR DESCRIPTION
When I set parameters allowAnyUpdates=false, allowMajorUpdates=false, allowMinorUpdates=false, allowIncrementalUpdates=false plugin works as if it was set allowAnyUpdates=true but it should look for the biggest build number.