### PR TITLE
Align license name to ASF standard from parent-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   <inceptionYear>2008</inceptionYear>
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Hereafter will be better aggregated in Maven licence reports