### PR TITLE
Fixed #208 - Cleaned up Javadoc

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,8 @@
 
  * [Fixed Issue 215][issue-215]
 
+ * [Fixed Issue 208][issue-208]
+
 ## 2.5
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,15 @@
           <mavenOpts>-Xmx256m</mavenOpts>
         </configuration>
       </plugin>
+      <plugin>
+        <!-- duplicated from reporting to allow configuration to be used with
+          "mvn javadoc:javadoc" as well as "mvn site" -->
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>${mojo.java.target}</source>
+          <excludePackageNames>org.codehaus.mojo.versions.model</excludePackageNames>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -454,10 +463,12 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <source>${mojo.java.target}</source>
+          <excludePackageNames>org.codehaus.mojo.versions.model</excludePackageNames>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.0.0</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
@@ -141,7 +140,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     /**
      * Should the project/dependencies section of the pom be processed.
      *
-     * @return returns <code>true if the project/dependencies section of the pom should be processed.
+     * @return returns {@code true} if the project/dependencies section of the pom should be processed.
      * @since 1.0-alpha-3
      */
     public boolean isProcessingDependencies()
@@ -152,7 +151,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     /**
      * Should the project/dependencyManagement section of the pom be processed.
      *
-     * @return returns <code>true if the project/dependencyManagement section of the pom should be processed.
+     * @return returns {@code true} if the project/dependencyManagement section of the pom should be processed.
      * @since 1.0-alpha-3
      */
     public boolean isProcessingDependencyManagement()
@@ -163,7 +162,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     /**
      * Should the project/parent section of the pom be processed.
      *
-     * @return returns <code>true if the project/parent section of the pom should be processed.
+     * @return returns {@code true} if the project/parent section of the pom should be processed.
      * @since 2.3
      */
     public boolean isProcessingParent()
@@ -174,7 +173,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     /**
      * Should the artifacts produced in the current reactor be excluded from processing.
      *
-     * @return returns <code>true if the artifacts produced in the current reactor should be excluded from processing.
+     * @return returns {@code true} if the artifacts produced in the current reactor should be excluded from processing.
      * @since 1.0-alpha-3
      */
     public boolean isExcludeReactor()
@@ -185,8 +184,8 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     /**
      * Try to find the dependency artifact that matches the given dependency.
      *
-     * @param dependency
-     * @return
+     * @param dependency the dependency to find a match for
+     * @return the matching artifact or null if no matching artifact exists
      * @since 1.0-alpha-3
      */
     protected Artifact findArtifact( Dependency dependency )
@@ -210,8 +209,9 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     /**
      * Try to find the dependency artifact that matches the given dependency.
      *
-     * @param dependency
-     * @return
+     * @param dependency the dependency to find a match for
+     * @return the matching artifact, newly created if needed
+     * @throws MojoExecutionException if the dependency version specification is invalid
      * @since 1.0-alpha-3
      */
     protected Artifact toArtifact( Dependency dependency )
@@ -290,10 +290,10 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     }
 
     /**
-     * Returns <code>true</code> if the dependency is produced by the current reactor.
+     * Returns {@code true} if the dependency is produced by the current reactor.
      *
      * @param dependency the dependency to heck.
-     * @return <code>true</code> if the dependency is produced by the current reactor.
+     * @return {@code true} if the dependency is produced by the current reactor.
      * @since 1.0-alpha-3
      */
     protected boolean isProducedByReactor( Dependency dependency )
@@ -389,7 +389,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
 
     /**
      * Indicates whether any includes were specified via the 'includes' or 'includesList' options.
-     * 
+     *
      * @return true if includes were specified, false otherwise.
      */
     protected boolean hasIncludes()

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -19,6 +19,9 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.manager.WagonManager;
@@ -43,10 +46,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.DefaultVersionsHelper;
 import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.plexus.i18n.I18N;
-
-import java.io.File;
-import java.util.List;
-import java.util.Locale;
 
 /**
  * Base class for all versions reports.
@@ -162,7 +161,7 @@ public abstract class AbstractVersionsReport
     /**
      * URI of a ruleSet file containing the rules that control how to compare
      * version numbers. The URI could be either a Wagon URI or a classpath URI
-     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).
+     * (e.g. {@code classpath:///package/sub/package/rules.xml}).
      *
      * @since 1.0-alpha-3
      */
@@ -170,8 +169,8 @@ public abstract class AbstractVersionsReport
     private String rulesUri;
 
     /**
-     * The versioning rule to use when comparing versions. Valid values are <code>maven</code>, <code>numeric</code>
-     * which will handle long version numbers provided all components are numeric, or <code>mercury</code> which will
+     * The versioning rule to use when comparing versions. Valid values are {@code maven}, {@code numeric}
+     * which will handle long version numbers provided all components are numeric, or {@code mercury} which will
      * use the mercury version number comparison rules.
      *
      * @since 1.0-alpha-1
@@ -253,6 +252,7 @@ public abstract class AbstractVersionsReport
      * @param locale the locale to generate the report for.
      * @param sink the report formatting tool.
      * @throws MavenReportException when things go wrong.
+     * @throws MojoExecutionException when things go wrong.
      */
     protected abstract void doGenerateReport( Locale locale, Sink sink )
         throws MavenReportException, MojoExecutionException;
@@ -262,10 +262,12 @@ public abstract class AbstractVersionsReport
      *
      * @param artifact The artifact.
      * @param versionRange The version range.
-     * @param allowingSnapshots <code>null</code> for no override, otherwise the local override to apply.
+     * @param allowingSnapshots {@code null} for no override, otherwise the local override to apply.
+     * @param usePluginRepositories {@code true} to use plugin repositories; {@code false} to use dependency
+     * repositories.
      * @return The latest version of the specified artifact that matches the specified version range or
-     *         <code>null</code> if no matching version could be found.
-     * @throws MojoExecutionException If the artifact metadata could not be found.
+     *         {@code null} if no matching version could be found.
+     * @throws MavenReportException If the artifact metadata could not be found.
      * @since 1.0-alpha-1
      */
     protected ArtifactVersion findLatestVersion( Artifact artifact, VersionRange versionRange,

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -19,6 +19,12 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
@@ -49,13 +55,6 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.WriterFactory;
 import org.codehaus.stax2.XMLInputFactory2;
-
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import java.io.File;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.List;
 
 /**
  * Abstract base class for Versions Mojos.
@@ -150,7 +149,7 @@ public abstract class AbstractVersionsUpdaterMojo
     /**
      * URI of a ruleSet file containing the rules that control how to compare
      * version numbers. The URI could be either a Wagon URI or a classpath URI
-     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).
+     * (e.g. {@code classpath:///package/sub/package/rules.xml}).
      *
      * @since 1.0-alpha-3
      */
@@ -257,16 +256,18 @@ public abstract class AbstractVersionsUpdaterMojo
      *
      * @param artifact The artifact.
      * @param versionRange The version range.
-     * @param allowingSnapshots <code>null</code> for no override, otherwise the local override to apply.
-     * @param usePluginRepositories
+     * @param allowingSnapshots {@code null} for no override, otherwise the local override to apply.
+     * @param usePluginRepositories {@code true} will consult the pluginRepositories, while {@code false} will
+     * consult the repositories for normal dependencies.
      * @return The latest version of the specified artifact that matches the specified version range or
-     *         <code>null</code> if no matching version could be found.
+     *         {@code null} if no matching version could be found.
      * @throws ArtifactMetadataRetrievalException If the artifact metadata could not be found.
+     * @throws MojoExecutionException If unable to load rules.
      * @since 1.0-alpha-1
      */
     protected ArtifactVersion findLatestVersion( Artifact artifact, VersionRange versionRange,
                                                  Boolean allowingSnapshots, boolean usePluginRepositories )
-        throws ArtifactMetadataRetrievalException, MojoExecutionException
+            throws ArtifactMetadataRetrievalException, MojoExecutionException
     {
         boolean includeSnapshots = this.allowSnapshots;
         if ( Boolean.TRUE.equals( allowingSnapshots ) )
@@ -287,7 +288,7 @@ public abstract class AbstractVersionsUpdaterMojo
      *
      * @param pom The pom.
      * @param property The property.
-     * @return The value as defined in the pom or <code>null</code> if not defined.
+     * @return The value as defined in the pom or {@code null} if not defined.
      * @since 1.0-alpha-1
      */
     protected String getPropertyValue( StringBuilder pom, String property )
@@ -399,19 +400,20 @@ public abstract class AbstractVersionsUpdaterMojo
      * @param pom The pom to update.
      * @throws MojoExecutionException If things go wrong.
      * @throws MojoFailureException If things go wrong.
-     * @throws javax.xml.stream.XMLStreamException If things go wrong.
+     * @throws XMLStreamException If things go wrong.
+     * @throws ArtifactMetadataRetrievalException If the artifact metadata could not be found.
      * @since 1.0-alpha-1
      */
     protected abstract void update( ModifiedPomXMLEventReader pom )
         throws MojoExecutionException, MojoFailureException, XMLStreamException, ArtifactMetadataRetrievalException;
 
     /**
-     * Returns <code>true</code> if the update should be applied.
+     * Returns {@code true} if the update should be applied.
      *
      * @param artifact The artifact.
      * @param currentVersion The current version of the artifact.
      * @param updateVersion The proposed new version of the artifact.
-     * @return <code>true</code> if the update should be applied.
+     * @return {@code true} if the update should be applied.
      * @since 1.0-alpha-1
      */
     protected boolean shouldApplyUpdate( Artifact artifact, String currentVersion, ArtifactVersion updateVersion )
@@ -452,9 +454,9 @@ public abstract class AbstractVersionsUpdaterMojo
      * Based on the passed flags, determines which segment is unchangable. This can be used when determining an upper
      * bound for the "latest" version.
      *
-     * @param allowMajorUpdates
-     * @param allowMinorUpdates
-     * @param allowIncrementalUpdates
+     * @param allowMajorUpdates {@code true} to allow major updates; {@code false} otherwise
+     * @param allowMinorUpdates {@code true} to allow minor updates; {@code false} otherwise
+     * @param allowIncrementalUpdates {@code true} to allow incremental updates; {@code false} otherwise
      * @return Returns the segment that is unchangable. If any segment can change, returns -1.
      */
     protected int determineUnchangedSegment( boolean allowMajorUpdates, boolean allowMinorUpdates,

--- a/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
@@ -27,9 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.stream.XMLStreamException;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -90,9 +88,7 @@ public class CompareDependenciesMojo
     protected boolean updateDependencies;
 
     /**
-     * Update dependency versions stored in properties
-     *
-     * @parameter property="updatePropertyVersions" default-value="false"
+     * Update dependency versions stored in properties.
      */
     @Parameter( property = "updatePropertyVersions", defaultValue = "false" )
     protected boolean updatePropertyVersions;
@@ -120,9 +116,9 @@ public class CompareDependenciesMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException Something wrong with the plugin itself
-     * @throws org.apache.maven.plugin.MojoFailureException The plugin detected an error in the build
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException Something wrong with the plugin itself
+     * @throws MojoFailureException The plugin detected an error in the build
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
@@ -51,8 +51,8 @@ public class DependencyUpdatesReport
 {
 
     /**
-     * Whether to process the <code>dependencyManagement</code> in pom or not.
-     * 
+     * Whether to process the {@code dependencyManagement} in pom or not.
+     *
      * @since 2.5
      */
     @Parameter( property = "processDependencyManagement", defaultValue = "true" )
@@ -60,12 +60,10 @@ public class DependencyUpdatesReport
 
     /**
      * Whether to process the depdendencyManagement part transitive or not.
-     * In case of <code>&lt;type&gt;pom&lt;/type&gt;</code>and
-     * <code>&lt;scope&gt;import&lt;/scope&gt;</code> this means
-     * by default to report also the imported dependencies. 
-     * If processTransitive is set to <code>false</code> the report will only show
-     * updates of the imported pom it self.
-     * 
+     * In case of {@code <type>pom</type>} and
+     * {@code <scope>import</scope>} this means by default to report also the imported dependencies. If
+     * processTransitive is set to {@code false} the report will only show updates of the imported pom it self.
+     *
      * @since 2.5 Note: Currently in experimental state.
      */
     @Parameter( property = "processDependencyManagementTransitive", defaultValue = "true" )
@@ -73,7 +71,7 @@ public class DependencyUpdatesReport
 
     /**
      * Report formats (html and/or xml). HTML by default.
-     * 
+     *
      */
     @Parameter( property = "dependencyUpdatesReportFormats", defaultValue = "html" )
     private String[] formats = new String[] { "html" };

--- a/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRenderer.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.reporting.MavenReportException;
@@ -36,7 +35,7 @@ import org.codehaus.mojo.versions.utils.DependencyComparator;
 /**
  * XML renderer for DependencyUpdatesReport creates an xml file in target directory and writes report about available
  * dependency/dependency management updates.
- * 
+ *
  * @author Illia Dubinin
  * @since 2.4
  */
@@ -86,7 +85,7 @@ public class DependencyUpdatesXmlRenderer
 
     /**
      * Makes report file with given name in target directory.
-     * 
+     *
      * @throws MavenReportException if something went wrong
      */
     public void render()
@@ -117,8 +116,8 @@ public class DependencyUpdatesXmlRenderer
 
     /**
      * Method wraps value in xml tag. In ex: to wrap foo in tag bar you have to pass foo as value and bar as tag. As a
-     * result you will get: <bar>foo</bar>
-     * 
+     * result you will get: {@code <bar>foo</bar>}
+     *
      * @param value - string to wrap
      * @param tag - name of tag
      * @return value wrapped in xml tag
@@ -132,7 +131,7 @@ public class DependencyUpdatesXmlRenderer
     /**
      * Returns summary of dependency analysis result in xml format: current version, next available, next incremental,
      * next minor and next major versions.
-     * 
+     *
      * @param allUpdates all dependencies versions
      * @return summary in xml format
      */
@@ -180,7 +179,7 @@ public class DependencyUpdatesXmlRenderer
      * Returns xml report for current dependency state with following info: current version, next available version,
      * next incremental/minor/major if available and status ('incremental available', 'minor available', 'major
      * available' or 'no new available')
-     * 
+     *
      * @param versions version info for dependency
      * @return xml reports about current possible updates.
      */

--- a/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -19,6 +19,13 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -35,15 +42,6 @@ import org.codehaus.mojo.versions.api.UpdateScope;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
 import org.codehaus.plexus.util.StringUtils;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
-import javax.xml.stream.XMLStreamException;
 
 /**
  * Displays all dependencies that have newer versions available.
@@ -101,8 +99,8 @@ public class DisplayDependencyUpdatesMojo
 
     /**
      * Whether to allow the major version number to be changed.
-     * You need to set {@link #allowAnyUpdates} to <code>false</code> to
-     * get this configuration gets control. 
+     * You need to set {@link #allowAnyUpdates} to {@code false} to
+     * get this configuration gets control.
      * @since 2.5
      */
     @Parameter(property = "allowMajorUpdates", defaultValue = "true")
@@ -110,8 +108,8 @@ public class DisplayDependencyUpdatesMojo
 
     /**
      * Whether to allow the minor version number to be changed.
-     * You need to set {@link #allowMajorUpdates} to <code>false</code> to
-     * get this configuration gets control. 
+     * You need to set {@link #allowMajorUpdates} to {@code false} to
+     * get this configuration gets control.
      *
      * @since 2.5
      */
@@ -120,8 +118,8 @@ public class DisplayDependencyUpdatesMojo
 
     /**
      * Whether to allow the incremental version number to be changed.
-     * You need to set {@link #allowMinorUpdates} to <code>false</code> to
-     * get this configuration gets control. 
+     * You need to set {@link #allowMinorUpdates} to {@code false} to
+     * get this configuration gets control.
      *
      * @since 2.5
      */
@@ -255,8 +253,8 @@ public class DisplayDependencyUpdatesMojo
     // --------------------- Interface Mojo ---------------------
 
     /**
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#execute()
      * @since 1.0-alpha-1
      */
@@ -455,9 +453,9 @@ public class DisplayDependencyUpdatesMojo
                 }
                 logLine( false, "" );
             }
-        }        
-        
-        
+        }
+
+
         if ( withUpdates.isEmpty() )
         {
             if ( !usingCurrent.isEmpty() )
@@ -480,9 +478,9 @@ public class DisplayDependencyUpdatesMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      * @since 1.0-alpha-1
      */

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -19,6 +19,31 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
 import org.apache.maven.BuildFailureException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
@@ -68,32 +93,6 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.events.XMLEvent;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.regex.Pattern;
 
 /**
  * Displays all plugins that have newer versions available.
@@ -923,7 +922,7 @@ public class DisplayPluginUpdatesMojo
      * Gets the build plugins of a specific project.
      *
      * @param model the model to get the build plugins from.
-     * @param onlyIncludeInherited <code>true</code> to only return the plugins definitions that will be inherited by
+     * @param onlyIncludeInherited {@code true} to only return the plugins definitions that will be inherited by
      *            child projects.
      * @return The map of effective plugin versions keyed by coordinates.
      * @since 1.0-alpha-1
@@ -994,7 +993,7 @@ public class DisplayPluginUpdatesMojo
      *
      * @param project the project to get the lifecycle plugins from.
      * @return The map of effective plugin versions keyed by coordinates.
-     * @throws org.apache.maven.plugin.MojoExecutionException if things go wrong.
+     * @throws MojoExecutionException if things go wrong.
      * @since 1.0-alpha-1
      */
     private Map<String, Plugin> getLifecyclePlugins( MavenProject project )
@@ -1036,7 +1035,7 @@ public class DisplayPluginUpdatesMojo
      * @param project the project
      * @param thePhases the the phases
      * @return the bound plugins
-     * @throws org.apache.maven.plugin.PluginNotFoundException the plugin not found exception
+     * @throws PluginNotFoundException the plugin not found exception
      * @throws LifecycleExecutionException the lifecycle execution exception
      * @throws IllegalAccessException the illegal access exception
      */
@@ -1364,7 +1363,7 @@ public class DisplayPluginUpdatesMojo
      *
      * @param project The maven project to get the parents of
      * @return the parent projects of the specified project, with the root project first.
-     * @throws org.apache.maven.plugin.MojoExecutionException if the super-pom could not be created.
+     * @throws MojoExecutionException if the super-pom could not be created.
      * @since 1.0-alpha-1
      */
     private List<MavenProject> getParentProjects( MavenProject project )
@@ -1429,7 +1428,7 @@ public class DisplayPluginUpdatesMojo
      * @param parentReportPlugins the parent pom's report plugins.
      * @param pluginsWithVersionsSpecified the plugin coords that have a version defined in the project.
      * @return the set of plugins used by the project.
-     * @throws org.apache.maven.plugin.MojoExecutionException if things go wrong.
+     * @throws MojoExecutionException if things go wrong.
      */
     private Set<Plugin> getProjectPlugins( Map<String, String> superPomPluginManagement,
                                            Map<String, String> parentPluginManagement,
@@ -1828,7 +1827,7 @@ public class DisplayPluginUpdatesMojo
      * Gets the report plugins of a specific project.
      *
      * @param model the model to get the report plugins from.
-     * @param onlyIncludeInherited <code>true</code> to only return the plugins definitions that will be inherited by
+     * @param onlyIncludeInherited {@code true} to only return the plugins definitions that will be inherited by
      *            child projects.
      * @return The map of effective plugin versions keyed by coordinates.
      * @since 1.0-alpha-1

--- a/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
@@ -19,6 +19,11 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -29,12 +34,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Replaces any -SNAPSHOT versions with a release version, older if necessary (if there has been a release).
@@ -58,9 +57,9 @@ public class ForceReleasesMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/Property.java
+++ b/src/main/java/org/codehaus/mojo/versions/Property.java
@@ -72,8 +72,8 @@ public class Property
     private boolean searchReactor;
 
     /**
-     * When {@link #searchReactor} is <code>true</code> and a property version can be entirely satisfied from the
-     * reactor and this setting is <code>true</code> then the reactor version will be specified irrespective of any
+     * When {@link #searchReactor} is {@code true} and a property version can be entirely satisfied from the
+     * reactor and this setting is {@code true} then the reactor version will be specified irrespective of any
      * other settings (including {@link #banSnapshots}).
      *
      * @parameter default-value="true"

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -31,9 +31,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
-
 import javax.xml.stream.XMLStreamException;
-
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
@@ -80,8 +78,8 @@ public class SetMojo
 
     /**
      * The groupId of the dependency/module to update.
-     * If you like to update modules of a aggregator you 
-     * should set <code>-DgroupId='*'</code> to ignore the
+     * If you like to update modules of a aggregator you
+     * should set {@code -DgroupId='*'} to ignore the
      * group of the current project. On Windows you can omit
      * the single quotes on Linux they are necessary to prevent
      * expansion through the shell.
@@ -93,8 +91,8 @@ public class SetMojo
 
     /**
      * The artifactId of the dependency/module to update.
-     * If you like to update modules of a aggregator you 
-     * should set <code>-DartifactId='*'</code> to ignore the
+     * If you like to update modules of a aggregator you
+     * should set {@code -DartifactId='*'} to ignore the
      * artifactId of the current project. On Windows you can omit
      * the single quotes on Linux they are necessary to prevent
      * expansion through the shell.
@@ -107,7 +105,7 @@ public class SetMojo
     /**
      * The version of the dependency/module to update.
      * If you are changing an aggregator you should give
-     * <code>-DoldVersion='*'</code> to suppress the check against the
+     * {@code -DoldVersion='*'} to suppress the check against the
      * version of the current project. On Windows you can omit
      * the single quotes on Linux they are necessary to prevent
      * expansion through the shell.
@@ -165,7 +163,7 @@ public class SetMojo
     private Prompter prompter;
 
     /**
-     * Whether to remove <code>-SNAPSHOT</code> from the existing version.
+     * Whether to remove {@code -SNAPSHOT} from the existing version.
      *
      * @since 2.10
      */
@@ -173,7 +171,7 @@ public class SetMojo
     private boolean removeSnapshot;
 
     /**
-     * Whether to add next version number and <code>-SNAPSHOT</code> to the existing version.
+     * Whether to add next version number and {@code -SNAPSHOT} to the existing version.
      *
      * @since 2.10
      */
@@ -204,8 +202,8 @@ public class SetMojo
     /**
      * Called when this mojo is executed.
      *
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong.
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong.
+     * @throws MojoExecutionException when things go wrong.
+     * @throws MojoFailureException when things go wrong.
      */
     public void execute()
         throws MojoExecutionException, MojoFailureException
@@ -467,9 +465,9 @@ public class SetMojo
      * Updates the pom file.
      *
      * @param pom The pom file to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong.
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong.
-     * @throws javax.xml.stream.XMLStreamException when things go wrong.
+     * @throws MojoExecutionException when things go wrong.
+     * @throws MojoFailureException when things go wrong.
+     * @throws XMLStreamException when things go wrong.
      */
     protected synchronized void update( ModifiedPomXMLEventReader pom )
         throws MojoExecutionException, MojoFailureException, XMLStreamException

--- a/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -32,8 +32,8 @@ import java.util.Map;
 
 /**
  * Set a property to a given version without any sanity checks. Please be careful this can lead to changes which might
- * not build anymore. The sanity checks are done by other goals like <code>update-properties</code> or
- * <code>update-property</code> etc. they are not done here. So use this goal with care.
+ * not build anymore. The sanity checks are done by other goals like {@code update-properties} or
+ * {@code update-property} etc. they are not done here. So use this goal with care.
  *
  * @author Karl Heinz Marbaise
  * @since 2.5

--- a/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
@@ -1,11 +1,8 @@
 package org.codehaus.mojo.versions;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
-
 import java.io.IOException;
-
 import javax.xml.stream.XMLStreamException;
-
+import static org.apache.commons.lang.StringUtils.isBlank;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Scm;
@@ -38,8 +35,8 @@ public class SetScmTagMojo
     /**
      * Called when this mojo is executed.
      *
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong.
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong.
+     * @throws MojoExecutionException when things go wrong.
+     * @throws MojoFailureException when things go wrong.
      */
 	@Override
     public void execute()

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
@@ -76,8 +76,8 @@ public class UpdatePropertiesMojo
     private boolean autoLinkItems;
 
     /**
-     * If a property points to a version like <code>1.2.3-SNAPSHOT</code> and your repo contains a version like
-     * <code>1.1.0</code> without settings this to <code>true</code> the property will not being changed.
+     * If a property points to a version like {@code 1.2.3-SNAPSHOT} and your repo contains a version like
+     * {@code 1.1.0} without settings this to {@code true} the property will not being changed.
      * 
      * @since 2.4
      */

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -19,15 +19,14 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Map;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.Map;
 
 /**
  * Sets a property to the latest version in a given range of associated artifacts.
@@ -44,7 +43,7 @@ public class UpdatePropertyMojo
 
     /**
      * A property to update.
-     * 
+     *
      * @since 1.3
      */
     @Parameter( property = "property" )
@@ -53,17 +52,17 @@ public class UpdatePropertyMojo
     /**
      * The new version to set the property to (can be a version range to find a version within).
      * <ul>
-     * <li><code>1.0</code>x >= 1.0. The default Maven meaning for 1.0 is everything (,) but with 1.0 recommended.</li>
-     * <li><code>[1.0,2.0)</code> Versions 1.0 (included) to 2.0 (not included)</li>
-     * <li><code>[1.0,2.0]</code> Versions 1.0 to 2.0 (both included)</li>
-     * <li><code>[1.5,)</code> Versions 1.5 and higher</li>
-     * <li><code>(,1.0],[1.2,)</code> Versions up to 1.0 (included) and 1.2 or higher</li>
+     * <li>{@code 1.0}x >= 1.0. The default Maven meaning for 1.0 is everything (,) but with 1.0 recommended.</li>
+     * <li>{@code [1.0,2.0)} Versions 1.0 (included) to 2.0 (not included)</li>
+     * <li>{@code [1.0,2.0]} Versions 1.0 to 2.0 (both included)</li>
+     * <li>{@code [1.5,)} Versions 1.5 and higher</li>
+     * <li>{@code (,1.0],[1.2,)} Versions up to 1.0 (included) and 1.2 or higher</li>
      * </ul>
      * If you like to define the version to be used exactly you have to use it like this:
-     * <code>-DnewVersion=[19.0]</code> otherwise a newer existing version will be used. If you need to downgrade a
-     * version you have to define <code>-DallowDowngrade=true</code> as well otherwise
+     * {@code -DnewVersion=[19.0]} otherwise a newer existing version will be used. If you need to downgrade a
+     * version you have to define {@code -DallowDowngrade=true} as well otherwise
      * the version will be kept.
-     * 
+     *
      * @since 1.3
      */
     @Parameter( property = "newVersion" )
@@ -78,10 +77,11 @@ public class UpdatePropertyMojo
     private boolean autoLinkItems;
 
     /**
-     * If a property points to a version like <code>1.2.3</code> and your repository contains versions like
-     * <code>1.2.3</code> and <code>1.1.0</code> without settings this to <code>true</code> the property will never
-     * being changed back to <code>1.1.0</code> by using <code>-DnewVersion=[1.1.0]</code>.
-     * 
+     * If a property points to a version like {@code 1.2.3} and your repository contains versions like
+     * {@code 1.2.3} and {@code 1.1.0} without settings this to {@code true} the property will never
+     * being changed back to {@code 1.1.0}
+     * by using {@code -DnewVersion=[1.1.0]}.
+       *
      * @since 3.0.0
      */
     @Parameter( property = "allowDowngrade", defaultValue = "false" )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -19,6 +19,13 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -35,14 +42,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.MajorMinorIncrementalFilter;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Replaces any release versions with the latest release version.
@@ -90,9 +89,9 @@ public class UseLatestReleasesMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -19,6 +19,12 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -32,13 +38,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Replaces any release versions with the latest snapshot version (if it has been deployed).
@@ -61,7 +60,7 @@ public class UseLatestSnapshotsMojo
 
     /**
      * Whether to allow the minor version number to be changed.
-     * 
+     *
      * @since 1.0-beta-1
      */
     @Parameter( property = "allowMinorUpdates", defaultValue = "false" )
@@ -86,9 +85,9 @@ public class UseLatestSnapshotsMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -22,9 +22,7 @@ package org.codehaus.mojo.versions;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-
 import javax.xml.stream.XMLStreamException;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -78,9 +76,9 @@ public class UseLatestVersionsMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -19,6 +19,11 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -29,12 +34,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Replaces any release versions with the next release version (if it has been released).
@@ -58,9 +57,9 @@ public class UseNextReleasesMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -19,6 +19,12 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -32,13 +38,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Replaces any release versions with the next snapshot version (if it has been deployed).
@@ -86,9 +85,9 @@ public class UseNextSnapshotsMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
@@ -19,6 +19,9 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Collection;
+import java.util.Iterator;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -29,10 +32,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import javax.xml.stream.XMLStreamException;
-import java.util.Collection;
-import java.util.Iterator;
 
 /**
  * Replaces any version with the latest version.
@@ -49,9 +48,9 @@ public class UseNextVersionsMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
@@ -20,9 +20,7 @@ package org.codehaus.mojo.versions;
  */
 
 import java.util.Collection;
-
 import javax.xml.stream.XMLStreamException;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
@@ -49,9 +47,9 @@ public class UseReactorMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -19,6 +19,11 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -33,13 +38,6 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-
-import java.util.Collection;
-import java.util.NoSuchElementException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.xml.stream.XMLStreamException;
 
 /**
  * Replaces any -SNAPSHOT versions with the corresponding release version (if it has been released).
@@ -79,9 +77,9 @@ public class UseReleasesMojo
 
     /**
      * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @throws MojoExecutionException when things go wrong
+     * @throws MojoFailureException when things go wrong in a very bad way
+     * @throws XMLStreamException when things go wrong with XML streaming
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
      */
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
@@ -82,12 +82,12 @@ public class ArtifactVersions
     }
 
     /**
-     * Checks if the version is in the range (and ensures that the range respects the <code>-!</code> syntax to rule out
+     * Checks if the version is in the range (and ensures that the range respects the {@code -!} syntax to rule out
      * any qualifiers from range boundaries).
      *
      * @param version the version to check.
      * @param range the range to check.
-     * @return <code>true</code> if and only if the version is in the range.
+     * @return {@code true} if and only if the version is in the range.
      * @since 1.3
      */
     public static boolean isVersionInRange( ArtifactVersion version, VersionRange range )

--- a/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -19,6 +19,27 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.io.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -65,28 +86,6 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluatio
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-
-import java.io.*;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.regex.Pattern;
 
 /**
  * Helper class that provides common functionality required by both the mojos and the reports.
@@ -180,7 +179,7 @@ public class DefaultVersionsHelper
      * Constructs a new {@link DefaultVersionsHelper}.
      *
      * @param artifactFactory The artifact factory.
-     * @param artifactResolver
+     * @param artifactResolver The object responsible for getting the artifact.
      * @param artifactMetadataSource The artifact metadata source to use.
      * @param remoteArtifactRepositories The remote artifact repositories to consult.
      * @param remotePluginRepositories The remote plugin repositories to consult.
@@ -191,8 +190,8 @@ public class DefaultVersionsHelper
      * @param rulesUri The URL to retrieve the versioning rules from.
      * @param log The {@link org.apache.maven.plugin.logging.Log} to send log messages to.
      * @param mavenSession The maven session information.
-     * @param pathTranslator The path translator component. @throws org.apache.maven.plugin.MojoExecutionException If
-     *            things go wrong.
+     * @param pathTranslator The path translator component.
+     * @throws MojoExecutionException If unable to load rules.
      * @since 1.0-alpha-3
      */
     public DefaultVersionsHelper( ArtifactFactory artifactFactory, ArtifactResolver artifactResolver,

--- a/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -19,6 +19,30 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
@@ -43,32 +67,6 @@ import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.events.XMLEvent;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Helper class for modifying pom files.
@@ -140,7 +138,7 @@ public class PomHelper
      * @param profileId The profile in which to modify the property.
      * @param property The property to modify.
      * @param value The new value of the property.
-     * @return <code>true</code> if a replacement was made.
+     * @return {@code true} if a replacement was made.
      * @throws XMLStreamException if somethinh went wrong.
      */
     public static boolean setPropertyVersion( final ModifiedPomXMLEventReader pom, final String profileId,
@@ -225,7 +223,7 @@ public class PomHelper
      *
      * @param pom The pom to modify.
      * @param value The new value of the property.
-     * @return <code>true</code> if a replacement was made.
+     * @return {@code true} if a replacement was made.
      * @throws XMLStreamException if somethinh went wrong.
      */
     public static boolean setProjectVersion( final ModifiedPomXMLEventReader pom, final String value )
@@ -240,7 +238,7 @@ public class PomHelper
      * @param pom The pom to modify.
      * @param pattern The pattern to look for.
      * @param value The new value of the property.
-     * @return <code>true</code> if a replacement was made.
+     * @return {@code true} if a replacement was made.
      * @throws XMLStreamException if something went wrong.
      */
     public static boolean setProjectValue( final ModifiedPomXMLEventReader pom, String pattern, final String value )
@@ -290,7 +288,7 @@ public class PomHelper
      * Retrieves the project version from the pom.
      *
      * @param pom The pom.
-     * @return the project version or <code>null</code> if the project version is not defined (i.e. inherited from
+     * @return the project version or {@code null} if the project version is not defined (i.e. inherited from
      *         parent version).
      * @throws XMLStreamException if something went wrong.
      */
@@ -339,7 +337,7 @@ public class PomHelper
      *
      * @param pom The pom to modify.
      * @param value The new value of the property.
-     * @return <code>true</code> if a replacement was made.
+     * @return {@code true} if a replacement was made.
      * @throws XMLStreamException if somethinh went wrong.
      */
     public static boolean setProjectParentVersion( final ModifiedPomXMLEventReader pom, final String value )
@@ -390,7 +388,7 @@ public class PomHelper
      *
      * @param pom The pom.
      * @param helper The helper (used to create the artifact).
-     * @return The parent artifact or <code>null</code> if no parent is specified.
+     * @return The parent artifact or {@code null} if no parent is specified.
      * @throws XMLStreamException if something went wrong.
      */
     public static Artifact getProjectParent( final ModifiedPomXMLEventReader pom, VersionsHelper helper )
@@ -455,7 +453,7 @@ public class PomHelper
      * @param oldVersion The old version of the dependency.
      * @param newVersion The new version of the dependency.
      * @param model The model to get the project properties from.
-     * @return <code>true</code> if a replacement was made.
+     * @return {@code true} if a replacement was made.
      * @throws XMLStreamException if something went wrong.
      */
     public static boolean setDependencyVersion( final ModifiedPomXMLEventReader pom, final String groupId,
@@ -759,7 +757,7 @@ public class PomHelper
      * @param artifactId The artifactId of the dependency.
      * @param oldVersion The old version of the dependency.
      * @param newVersion The new version of the dependency.
-     * @return <code>true</code> if a replacement was made.
+     * @return {@code true} if a replacement was made.
      * @throws XMLStreamException if somethinh went wrong.
      */
     public static boolean setPluginVersion( final ModifiedPomXMLEventReader pom, final String groupId,
@@ -1379,6 +1377,7 @@ public class PomHelper
     /**
      * Finds the local root of the specified project.
      *
+     * @param builder the builder to build the parent project.
      * @param project The project to find the local root for.
      * @param localRepository the local repo.
      * @param globalProfileManager the global profile manager.
@@ -1532,12 +1531,12 @@ public class PomHelper
     }
 
     /**
-     * Returns the model that has the specified groupId and artifactId or <code>null</code> if no such model exists.
+     * Returns the model that has the specified groupId and artifactId or {@code null} if no such model exists.
      *
      * @param reactor The map of models keyed by path.
      * @param groupId The groupId to match.
      * @param artifactId The artifactId to match.
-     * @return The model or <code>null</code> if the model was not in the reactor.
+     * @return The model or {@code null} if the model was not in the reactor.
      */
     public static Model getModel( Map<String, Model> reactor, String groupId, String artifactId )
     {
@@ -1546,12 +1545,12 @@ public class PomHelper
     }
 
     /**
-     * Returns the model that has the specified groupId and artifactId or <code>null</code> if no such model exists.
+     * Returns the model that has the specified groupId and artifactId or {@code null} if no such model exists.
      *
      * @param reactor The map of models keyed by path.
      * @param groupId The groupId to match.
      * @param artifactId The artifactId to match.
-     * @return The model entry or <code>null</code> if the model was not in the reactor.
+     * @return The model entry or {@code null} if the model was not in the reactor.
      */
     public static Map.Entry<String, Model> getModelEntry( Map<String, Model> reactor, String groupId,
                                                           String artifactId )
@@ -1621,9 +1620,9 @@ public class PomHelper
     /**
      * Reads imported POMs from the dependency management section.
      *
-     * @param pom
+     * @param pom the POM file to read
      * @return a non-null list of {@link Dependency} for each imported POM
-     * @throws XMLStreamException
+     * @throws XMLStreamException when things go wrong
      * @see <a href="https://github.com/mojohaus/versions-maven-plugin/issues/134">bug #134</a>
      * @since 2.4
      */

--- a/src/main/java/org/codehaus/mojo/versions/api/PropertyVersions.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PropertyVersions.java
@@ -19,17 +19,6 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.ArtifactUtils;
-import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
-import org.apache.maven.artifact.versioning.ArtifactVersion;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
-import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.mojo.versions.Property;
-import org.codehaus.mojo.versions.ordering.VersionComparator;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +29,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.mojo.versions.Property;
+import org.codehaus.mojo.versions.ordering.VersionComparator;
 
 /**
  * Manages a property that is associated with one or more artifacts.
@@ -160,7 +159,7 @@ public class PropertyVersions
      * @return The versions that can be resolved from the supplied Artifact instances or an empty array if no version
      *         can be resolved (i.e. the property is not associated with any of the supplied artifacts or the property
      *         is also associated to an artifact that has not been provided).
-     * @throws org.apache.maven.plugin.MojoExecutionException When things go wrong.
+     * @throws MojoExecutionException When things go wrong.
      * @since 1.0-alpha-3
      */
     public ArtifactVersion[] getVersions( Collection<Artifact> artifacts )

--- a/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
@@ -24,16 +24,15 @@ import java.io.Serializable;
 import java.io.StreamCorruptedException;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 
 /**
  * Scopes of version updates.
+ * <p>
+ * <b>TODO:</b> Convert this class to a Java 1.5 enum once we move to Java 1.5
  *
  * @author Stephen Connolly
- * @todo convert this class to a Java 1.5 enum once we move to Java 1.5
  * @since 1.0-beta-1
  */
 public abstract class UpdateScope
@@ -83,8 +82,8 @@ public abstract class UpdateScope
     };
 
     /**
-     * Incremental version updates, that is the third segment of the version number, for example <code>1.0.0.15</code>
-     * to <code>1.0.1.0</code>.
+     * Incremental version updates, that is the third segment of the version number, for example {@code 1.0.0.15}
+     * to {@code 1.0.1.0}.
      *
      * @since 1.0-beta-1
      */
@@ -126,8 +125,8 @@ public abstract class UpdateScope
     };
 
     /**
-     * Minor version updates, that is the second segment of the version number, for example <code>1.0.0.15</code> to
-     * <code>1.1.0.0</code>.
+     * Minor version updates, that is the second segment of the version number, for example {@code 1.0.0.15} to
+     * {@code 1.1.0.0}.
      *
      * @since 1.0-beta-1
      */
@@ -169,8 +168,8 @@ public abstract class UpdateScope
     };
 
     /**
-     * Major version updates, that is the first segment of the version number, for example <code>1.0.0.15</code> to
-     * <code>2.0.0.0</code>.
+     * Major version updates, that is the first segment of the version number, for example {@code 1.0.0.15} to
+     * {@code 2.0.0.0}.
      *
      * @since 1.0-beta-1
      */
@@ -244,8 +243,7 @@ public abstract class UpdateScope
      * @param versionDetails The versions to select from.
      * @param currentVersion The current version.
      * @param includeSnapshots Whether to include snapshots.
-     * @return The next version within this scope or <code>null</code> if there is no version within this scope.
-     * @throws ArtifactMetadataRetrievalException if there was a problem retrieving the list of available versions.
+     * @return The next version within this scope or {@code null} if there is no version within this scope.
      */
     public abstract ArtifactVersion getOldestUpdate( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                      boolean includeSnapshots );
@@ -256,7 +254,7 @@ public abstract class UpdateScope
      * @param versionDetails The versions to select from.
      * @param currentVersion The current version.
      * @param includeSnapshots Whether to include snapshots.
-     * @return The newest version within this scope or <code>null</code> if there is no version within this scope.
+     * @return The newest version within this scope or {@code null} if there is no version within this scope.
      */
     public abstract ArtifactVersion getNewestUpdate( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                      boolean includeSnapshots );
@@ -280,7 +278,7 @@ public abstract class UpdateScope
 
     /**
      * Returns the name of this enum constant, exactly as declared in its enum declaration.
-     * <p/>
+     * <p>
      * <b>Most programmers should use the {@link #toString} method in preference to this one, as the toString method may
      * return a more user-friendly name.</b> This method is designed primarily for use in specialized situations where
      * correctness depends on getting the exact name, which will not vary from release to release.
@@ -295,7 +293,7 @@ public abstract class UpdateScope
     /**
      * The ordinal of this enumeration constant (its position in the enum declaration, where the initial constant is
      * assigned an ordinal of zero).
-     * <p/>
+     * <p>
      * Most programmers will have no use for this field.
      */
     private final int ordinal;
@@ -303,7 +301,7 @@ public abstract class UpdateScope
     /**
      * Returns the ordinal of this enumeration constant (its position in its enum declaration, where the initial
      * constant is assigned an ordinal of zero).
-     * <p/>
+     * <p>
      * Most programmers will have no use for this method.
      *
      * @return the ordinal of this enumeration constant
@@ -365,7 +363,7 @@ public abstract class UpdateScope
     /**
      * Compares this enum with the specified object for order. Returns a negative integer, zero, or a positive integer
      * as this object is less than, equal to, or greater than the specified object.
-     * <p/>
+     * <p>
      * Enum constants are only comparable to other enum constants of the same enum type. The natural order implemented
      * by this method is the order in which the constants are declared.
      */

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -32,10 +32,10 @@ import org.codehaus.mojo.versions.ordering.VersionComparator;
 public interface VersionDetails
 {
     /**
-     * Returns <code>true</code> if the specific version is in the list of versions.
+     * Returns {@code true} if the specific version is in the list of versions.
      *
      * @param version the specific version.
-     * @return <code>true</code> if the specific version is in the list of versions.
+     * @return {@code true} if the specific version is in the list of versions.
      * @since 1.0-beta-1
      */
     boolean containsVersion( String version );
@@ -59,7 +59,7 @@ public interface VersionDetails
     /**
      * Returns all available versions in increasing order.
      *
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return all available versions in increasing order.
      * @since 1.0-alpha-3
      */
@@ -69,7 +69,7 @@ public interface VersionDetails
      * Returns all available versions within the specified version range.
      *
      * @param versionRange The version range within which the version must exist.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return all available versions within the specified version range.
      * @since 1.0-alpha-3
      */
@@ -78,8 +78,8 @@ public interface VersionDetails
     /**
      * Returns all available versions within the specified bounds.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
@@ -88,9 +88,9 @@ public interface VersionDetails
     /**
      * Returns all available versions within the specified bounds.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
@@ -99,11 +99,11 @@ public interface VersionDetails
     /**
      * Returns all available versions within the specified bounds.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true> if the upper bound is inclusive.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @param includeLower {@code true} if the lower bound is inclusive.
+     * @param includeUpper {@code true} if the upper bound is inclusive.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
@@ -113,13 +113,13 @@ public interface VersionDetails
     /**
      * Returns all available versions within the specified bounds.
      *
-     * @param versionRange The version range within which the version must exist where <code>null</code> imples
-     *            <code>[,)</code>.
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true> if the upper bound is inclusive.
+     * @param versionRange The version range within which the version must exist where {@code null} imples
+     *            {@code [,)}.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @param includeLower {@code true} if the lower bound is inclusive.
+     * @param includeUpper {@code true} if the upper bound is inclusive.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
@@ -128,23 +128,23 @@ public interface VersionDetails
 
     /**
      * Returns the latest version newer than the specified lowerBound, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @return the latest version between lowerBound and upperBound or {@code null} if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound );
 
     /**
      * Returns the latest version newer than the specified lowerBound, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the latest version between currentVersion and upperBound or <code>null</code> if no version is available.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the latest version between currentVersion and upperBound or {@code null} if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound,
@@ -152,14 +152,14 @@ public interface VersionDetails
 
     /**
      * Returns the latest version newer than the specified current version, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true> if the upper bound is inclusive.
-     * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @param includeLower {@code true} if the lower bound is inclusive.
+     * @param includeUpper {@code true} if the upper bound is inclusive.
+     * @return the latest version between lowerBound and upperBound or {@code null} if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
@@ -167,90 +167,90 @@ public interface VersionDetails
 
     /**
      * Returns the latest version newer than the specified current version, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param versionRange The version range within which the version must exist where <code>null</code> imples
-     *            <code>[,)</code>.
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true> if the upper bound is inclusive.
-     * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
+     * @param versionRange The version range within which the version must exist where {@code null} imples
+     *            {@code [,)}.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @param includeLower {@code true} if the lower bound is inclusive.
+     * @param includeUpper {@code true} if the upper bound is inclusive.
+     * @return the latest version between lowerBound and upperBound or {@code null} if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
                                       boolean includeSnapshots, boolean includeLower, boolean includeUpper );
 
     /**
-     * Returns the latest version within the specified version range or <code>null</code> if no such version exists.
+     * Returns the latest version within the specified version range or {@code null} if no such version exists.
      *
      * @param versionRange The version range within which the version must exist.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the latest version within the version range or <code>null</code> if no version is available.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the latest version within the version range or {@code null} if no version is available.
      * @since 1.0-alpha-3
      */
     ArtifactVersion getNewestVersion( VersionRange versionRange, boolean includeSnapshots );
 
     /**
      * Returns the oldest version after the specified lowerBound, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @return the next version between lowerBound and upperBound or <code>null</code> if no version is available.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @return the next version between lowerBound and upperBound or {@code null} if no version is available.
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound );
 
     /**
-     * Returns the oldest version within the specified version range or <code>null</code> if no such version exists.
+     * Returns the oldest version within the specified version range or {@code null} if no such version exists.
      *
      * @param versionRange The version range within which the version must exist.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the oldest version between currentVersion and upperBound or <code>null</code> if no version is available.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the oldest version between currentVersion and upperBound or {@code null} if no version is available.
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestVersion( VersionRange versionRange, boolean includeSnapshots );
 
     /**
      * Returns the oldest version newer than the specified lower bound, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the latest version between currentVersion and upperBound or <code>null</code> if no version is available.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the latest version between currentVersion and upperBound or {@code null} if no version is available.
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound,
                                       boolean includeSnapshots );
 
     /**
-     * Returns the oldest version within the specified bounds or <code>null</code> if no such version exists.
+     * Returns the oldest version within the specified bounds or {@code null} if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true> if the upper bound is inclusive.
-     * @return the oldest version between lowerBound and upperBound or <code>null</code> if no version is available.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @param includeLower {@code true} if the lower bound is inclusive.
+     * @param includeUpper {@code true} if the upper bound is inclusive.
+     * @return the oldest version between lowerBound and upperBound or {@code null} if no version is available.
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
                                       boolean includeLower, boolean includeUpper );
 
     /**
-     * Returns the oldest version within the specified bounds or <code>null</code> if no such version exists.
+     * Returns the oldest version within the specified bounds or {@code null} if no such version exists.
      *
-     * @param versionRange The version range within which the version must exist where <code>null</code> imples
-     *            <code>[,)</code>.
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true> if the upper bound is inclusive.
-     * @return the oldest version between lowerBound and upperBound or <code>null</code> if no version is available.
+     * @param versionRange The version range within which the version must exist where {@code null} imples
+     *            {@code [,)}.
+     * @param lowerBound the lower bound or {@code null} if the lower limit is unbounded.
+     * @param upperBound the upper bound or {@code null} if the upper limit is unbounded.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @param includeLower {@code true} if the lower bound is inclusive.
+     * @param includeUpper {@code true} if the upper bound is inclusive.
+     * @return the oldest version between lowerBound and upperBound or {@code null} if no version is available.
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestVersion( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
@@ -258,11 +258,11 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param updateScope the update scope to include.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -270,11 +270,11 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param updateScope the update scope to include.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -283,7 +283,7 @@ public interface VersionDetails
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param updateScope the update scope to include.
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
@@ -292,12 +292,12 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -306,12 +306,12 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -321,9 +321,9 @@ public interface VersionDetails
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */
@@ -332,11 +332,11 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param versionRange the version range to include.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -344,11 +344,11 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param versionRange the version range to include.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -357,7 +357,7 @@ public interface VersionDetails
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param versionRange the version range to include.
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
@@ -366,12 +366,12 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param versionRange the version range to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -380,12 +380,12 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param versionRange the version range to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -395,9 +395,9 @@ public interface VersionDetails
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
      *
-     * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
+     * @param currentVersion the lower bound or {@code null} if the lower limit is unbounded.
      * @param versionRange the version range to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */
@@ -405,9 +405,9 @@ public interface VersionDetails
                                      boolean includeSnapshots );
 
     /**
-     * Returns <code>true</code> if and only if <code>getCurrentVersion() != null</code>.
+     * Returns {@code true} if and only if {@code getCurrentVersion() != null}.
      *
-     * @return <code>true</code> if and only if <code>getCurrentVersion() != null</code>.
+     * @return {@code true} if and only if {@code getCurrentVersion() != null}.
      * @since 1.0-beta-1
      */
     boolean isCurrentVersionDefined();
@@ -435,17 +435,17 @@ public interface VersionDetails
     /**
      * Retrieves the current version.
      *
-     * @return The current version (may be <code>null</code>).
+     * @return The current version (may be {@code null}).
      * @since 1.0-beta-1
      */
     ArtifactVersion getCurrentVersion();
 
     /**
      * Returns the oldest version newer than the current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param updateScope the update scope to include.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -453,10 +453,10 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param updateScope the update scope to include.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -473,11 +473,11 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -485,11 +485,11 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -499,7 +499,7 @@ public interface VersionDetails
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
      *
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */
@@ -507,10 +507,10 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param versionRange the version range to include.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -518,10 +518,10 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param versionRange the version range to include.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -538,11 +538,11 @@ public interface VersionDetails
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param versionRange the version range to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the oldest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -550,11 +550,11 @@ public interface VersionDetails
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
-     * <code>null</code> if no such version exists.
+     * {@code null} if no such version exists.
      *
      * @param versionRange the version range to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
+     * @param includeSnapshots {@code true} if snapshots are to be included.
+     * @return the newest version after currentVersion within the specified update scope or {@code null} if no
      *         version is available.
      * @since 1.0-beta-1
      */
@@ -564,7 +564,7 @@ public interface VersionDetails
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
      *
      * @param versionRange the version range to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
@@ -18,12 +18,10 @@ package org.codehaus.mojo.versions.api;
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
@@ -50,6 +48,7 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator
  */
 public interface VersionsHelper
 {
+
     /**
      * Gets the logger used by this helper.
      *
@@ -85,7 +84,7 @@ public interface VersionsHelper
     ArtifactFactory getArtifactFactory();
 
     /**
-     * Shorthand method for <code>getArtifactFactory().createPluginArtifact(...)</code>.
+     * Shorthand method for {@code getArtifactFactory().createPluginArtifact(...)}.
      *
      * @param groupId The group Id.
      * @param artifactId The artifact Id.
@@ -96,7 +95,7 @@ public interface VersionsHelper
     Artifact createPluginArtifact( String groupId, String artifactId, VersionRange version );
 
     /**
-     * Shorthand method for <code>getArtifactFactory().createDependencyArtifact(...)</code>.
+     * Shorthand method for {@code getArtifactFactory().createDependencyArtifact(...)}.
      *
      * @param groupId The group id.
      * @param artifactId The artifact id.
@@ -109,10 +108,10 @@ public interface VersionsHelper
      * @since 1.0-alpha-3
      */
     Artifact createDependencyArtifact( String groupId, String artifactId, VersionRange version, String type,
-                                       String classifier, String scope, boolean optional );
+            String classifier, String scope, boolean optional );
 
     /**
-     * Shorthand method for <code>getArtifactFactory().createDependencyArtifact(...)</code>.
+     * Shorthand method for {@code getArtifactFactory().createDependencyArtifact(...)}.
      *
      * @param groupId The group id.
      * @param artifactId The artifact id.
@@ -124,11 +123,11 @@ public interface VersionsHelper
      * @since 1.0-beta-1
      */
     Artifact createDependencyArtifact( String groupId, String artifactId, VersionRange versionRange, String type,
-                                       String classifier, String scope );
+            String classifier, String scope );
 
     /**
-     * Shorthand method for <code>getArtifactFactory().createDependencyArtifact(...)</code> which extracts the
-     * parameters from the Dependency instance.
+     * Shorthand method for {@code getArtifactFactory().createDependencyArtifact(...)} which extracts the parameters
+     * from the Dependency instance.
      *
      * @param dependency The dependency to create the artifact for.
      * @return The corresponding dependency artifact.
@@ -136,7 +135,7 @@ public interface VersionsHelper
      * @since 1.0-alpha-3
      */
     Artifact createDependencyArtifact( Dependency dependency )
-        throws InvalidVersionSpecificationException;
+            throws InvalidVersionSpecificationException;
 
     /**
      * Takes a {@link List} of {@link org.apache.maven.project.MavenProject} instances and converts it into a
@@ -162,14 +161,14 @@ public interface VersionsHelper
      * appropriate remote repositories.
      *
      * @param artifact The artifact to look for versions of.
-     * @param usePluginRepositories <code>true</code> will consult the pluginRepositories, while <code>false</code> will
-     *            consult the repositories for normal dependencies.
+     * @param usePluginRepositories {@code true} will consult the pluginRepositories, while {@code false} will
+     * consult the repositories for normal dependencies.
      * @return The details of the available artifact versions.
      * @throws ArtifactMetadataRetrievalException When things go wrong.
      * @since 1.0-alpha-3
      */
     ArtifactVersions lookupArtifactVersions( Artifact artifact, boolean usePluginRepositories )
-        throws ArtifactMetadataRetrievalException;
+            throws ArtifactMetadataRetrievalException;
 
     /**
      * Looks up the updates of an artifact.
@@ -181,7 +180,7 @@ public interface VersionsHelper
      * @throws ArtifactMetadataRetrievalException When things go wrong.
      */
     ArtifactVersions lookupArtifactUpdates( Artifact artifact, boolean allowSnapshots, boolean usePluginRepositories )
-        throws ArtifactMetadataRetrievalException;
+            throws ArtifactMetadataRetrievalException;
 
     /**
      * Looks up the updates for a set of dependencies.
@@ -190,10 +189,11 @@ public interface VersionsHelper
      * @param usePluginRepositories Search the plugin repositories.
      * @return A map, keyed by dependency, with values of type {@link org.codehaus.mojo.versions.api.ArtifactVersions}.
      * @throws ArtifactMetadataRetrievalException When things go wrong.
+     * @throws InvalidVersionSpecificationException If the version specification for a dependency is invalid
      * @since 1.0-beta-1
      */
     Map<Dependency, ArtifactVersions> lookupDependenciesUpdates( Set dependencies, boolean usePluginRepositories )
-        throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
+            throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
 
     /**
      * Creates an {@link org.codehaus.mojo.versions.api.ArtifactVersions} instance from a dependency.
@@ -202,10 +202,11 @@ public interface VersionsHelper
      * @param usePluginRepositories Search the plugin repositories.
      * @return The details of updates to the dependency.
      * @throws ArtifactMetadataRetrievalException When things go wrong.
+     * @throws InvalidVersionSpecificationException If the version specification for the dependency is invalid
      * @since 1.0-beta-1
      */
     ArtifactVersions lookupDependencyUpdates( Dependency dependency, boolean usePluginRepositories )
-        throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
+            throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
 
     /**
      * Looks up the updates for a set of plugins.
@@ -214,10 +215,11 @@ public interface VersionsHelper
      * @param allowSnapshots Include snapshots in the list of updates.
      * @return A map, keyed by plugin, with values of type {@link org.codehaus.mojo.versions.PluginUpdatesDetails}.
      * @throws ArtifactMetadataRetrievalException When things go wrong.
+     * @throws InvalidVersionSpecificationException If the version specification for a plugin is invalid
      * @since 1.0-beta-1
      */
     Map<Plugin, PluginUpdatesDetails> lookupPluginsUpdates( Set<Plugin> plugins, boolean allowSnapshots )
-        throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
+            throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
 
     /**
      * Looks up the updates for a plugin.
@@ -230,7 +232,7 @@ public interface VersionsHelper
      * @since 1.0-beta-1
      */
     PluginUpdatesDetails lookupPluginUpdates( Plugin plugin, boolean allowSnapshots )
-        throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
+            throws ArtifactMetadataRetrievalException, InvalidVersionSpecificationException;
 
     /**
      * Returns an {@link ExpressionEvaluator} for the specified project.
@@ -252,21 +254,23 @@ public interface VersionsHelper
      * @param excludeProperties A comma separated list of properties to exclude.
      * @param autoLinkItems whether to automatically infer associations
      * @return a map of {@link org.codehaus.mojo.versions.api.PropertyVersions} values keyed by
-     *         {@link org.codehaus.mojo.versions.Property} instances.
+     * {@link org.codehaus.mojo.versions.Property} instances.
      * @throws MojoExecutionException if something goes wrong.
      */
     Map<Property, PropertyVersions> getVersionPropertiesMap( MavenProject project, Property[] propertyDefinitions,
-                                                             String includeProperties, String excludeProperties,
-                                                             boolean autoLinkItems )
-        throws MojoExecutionException;
+            String includeProperties, String excludeProperties,
+            boolean autoLinkItems )
+            throws MojoExecutionException;
 
     /**
      * Attempts to resolve the artifact.
      *
      * @param artifact The artifact to resolve.
      * @param usePluginRepositories whether to resolve from the plugin repositories or the regular repositories.
+     * @throws ArtifactResolutionException If unable to resolve the artifact for reasons other than it does not exist.
+     * @throws ArtifactNotFoundException If the artifact does not exist.
      * @since 1.3
      */
     void resolveArtifact( Artifact artifact, boolean usePluginRepositories )
-        throws ArtifactResolutionException, ArtifactNotFoundException;
+            throws ArtifactResolutionException, ArtifactNotFoundException;
 }

--- a/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
@@ -82,7 +82,7 @@ public abstract class AbstractVersionComparator
      * Returns true if this object is the same type of comparator as the parameter.
      *
      * @param obj the reference object with which to compare.
-     * @return <code>true</code> if this object is the same as the obj argument; <code>false</code> otherwise.
+     * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
      * @see #hashCode()
      * @see java.util.Hashtable
      */

--- a/src/main/java/org/codehaus/mojo/versions/ordering/MajorMinorIncrementalFilter.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/MajorMinorIncrementalFilter.java
@@ -28,8 +28,8 @@ import org.codehaus.mojo.versions.api.AbstractVersionDetails;
 /**
  * This class will handle the edge cases where a version update would have happened based on the usage of version ranges
  * to limit the replacement of the versions. We have currently the following scenario: The user defined
- * <code>allowMajorUpdates=false</code> and <code>allowMinorUpdates=true</code>. An given artifact
- * <code>groupId:artifactId:2.0.8</code> and a repository which contains the following versions of this artifact:
+ * {@code allowMajorUpdates=false} and {@code allowMinorUpdates=true}. An given artifact
+ * {@code groupId:artifactId:2.0.8} and a repository which contains the following versions of this artifact:
  * <ul>
  * <li>2.0.11</li>
  * <li>2.1.0-M1</li>
@@ -39,13 +39,13 @@ import org.codehaus.mojo.versions.api.AbstractVersionDetails;
  * <li>3.1.0</li>
  * <li>3.3.0</li>
  * </ul>
- * The {@link AbstractVersionDetails#getNewerVersions(String, int, boolean)} will use an upper version of
- * <code>2.1.0</code> to limit the versions to use. The result of this would be using <code>2.1.0-M1</code> which
- * contradicts the wish of the user of not updating the minor version. The root cause of this is the comparison of Maven
- * versions which will defined <code>2.1.0-M1</code> as less than <code>2.1.0</code>. The method
- * {@link #filter(ArtifactVersion, ArtifactVersion[])} will filter out those versions which violate the configuration
+ * The {@link AbstractVersionDetails#getNewerVersions(String, int, boolean)} will use an upper version of {@code 2.1.0}
+ * to limit the versions to use. The result of this would be using {@code 2.1.0-M1} which contradicts the wish of the
+ * user of not updating the minor version. The root cause of this is the comparison of Maven versions which will defined
+ * {@code 2.1.0-M1} as less than {@code 2.1.0}. The method {@link #filter(ArtifactVersion, ArtifactVersion[])} will
+ * filter out those versions which violate the configuration
  * {@link #allowMajorUpdates}, {@link #allowMinorUpdates} {@link #allowIncrementalUpdates}.
- * 
+ *
  * @author Karl Heinz Marbaise
  */
 public class MajorMinorIncrementalFilter

--- a/src/main/java/org/codehaus/mojo/versions/rewriting/ModifiedPomXMLEventReader.java
+++ b/src/main/java/org/codehaus/mojo/versions/rewriting/ModifiedPomXMLEventReader.java
@@ -19,22 +19,21 @@ package org.codehaus.mojo.versions.rewriting;
  * under the License.
  */
 
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-
+import java.io.IOException;
+import java.io.StringReader;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.XMLEvent;
-import java.io.IOException;
-import java.io.StringReader;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
  * Represents the modified pom file. Note: implementations of the StAX API (JSR-173) are not good round-trip rewriting
- * <b>while</b> keeping all unchanged bytes in the file as is. For example, the StAX API specifies that <code>CR</code>
- * characters will be stripped. Current implementations do not keep &quot; and &apos; characters consistent.
+ * <b>while</b> keeping all unchanged bytes in the file as is. For example, the StAX API specifies that {@code CR}
+ * characters will be stripped. Current implementations do not keep " and ' characters consistent.
  *
  * @author Stephen Connolly
  */
@@ -405,9 +404,9 @@ public class ModifiedPomXMLEventReader
     }
 
     /**
-     * Returns <code>true</code> if nextEnd is including the start of and end element.
+     * Returns {@code true} if nextEnd is including the start of and end element.
      *
-     * @return <code>true</code> if nextEnd is including the start of and end element.
+     * @return {@code true} if nextEnd is including the start of and end element.
      */
     private boolean nextEndIncludesNextEndElement()
     {
@@ -415,9 +414,9 @@ public class ModifiedPomXMLEventReader
     }
 
     /**
-     * Returns <code>true</code> if nextEnd is including the start of the next event.
+     * Returns {@code true} if nextEnd is including the start of the next event.
      *
-     * @return <code>true</code> if nextEnd is including the start of the next event.
+     * @return {@code true} if nextEnd is including the start of the next event.
      */
     private boolean nextEndIncludesNextEvent()
     {
@@ -468,10 +467,10 @@ public class ModifiedPomXMLEventReader
     }
 
     /**
-     * Returns <code>true</code> if the specified mark is defined.
+     * Returns {@code true} if the specified mark is defined.
      *
      * @param index The mark.
-     * @return <code>true</code> if the specified mark is defined.
+     * @return {@code true} if the specified mark is defined.
      */
     public boolean hasMark( int index )
     {

--- a/src/main/java/org/codehaus/mojo/versions/utils/RegexUtils.java
+++ b/src/main/java/org/codehaus/mojo/versions/utils/RegexUtils.java
@@ -116,8 +116,8 @@ public final class RegexUtils
      * Converts a wildcard rule to a regex rule.
      *
      * @param wildcardRule the wildcard rule.
-     * @param exactMatch <code>true</code> results in an regex that will match the entire string, while
-     *            <code>false</code> will match the start of the string.
+     * @param exactMatch {@code true} results in an regex that will match the entire string, while
+     *            {@code false} will match the start of the string.
      * @return The regex rule.
      */
     public static String convertWildcardsToRegex( String wildcardRule, boolean exactMatch )

--- a/src/main/java/org/codehaus/mojo/versions/utils/WagonUtils.java
+++ b/src/main/java/org/codehaus/mojo/versions/utils/WagonUtils.java
@@ -50,7 +50,7 @@ public final class WagonUtils
      * {@link org.apache.maven.settings.Settings} into a {@link org.apache.maven.wagon.proxy.ProxyInfo}.
      *
      * @param settings The settings to use.
-     * @return The proxy details from the settings or <code>null</code> if the settings do not define a proxy.
+     * @return The proxy details from the settings or {@code null} if the settings do not define a proxy.
      */
     public static ProxyInfo getProxyInfo( Settings settings )
     {
@@ -74,14 +74,14 @@ public final class WagonUtils
      *
      * @param serverId The serverId to use if the wagonManager needs help.
      * @param url The url to create a wagon for.
-     * @param wagonManager The wgaon manager to use.
+     * @param wagonManager The wagon manager to use.
      * @param settings The settings to use.
      * @param logger The logger to use.
      * @return The wagon to connect to the url.
-     * @throws org.apache.maven.wagon.UnsupportedProtocolException if the protocol is not supported.
-     * @throws org.apache.maven.artifact.manager.WagonConfigurationException if the wagon cannot be configured.
-     * @throws org.apache.maven.wagon.ConnectionException If the connection cannot be established.
-     * @throws org.apache.maven.wagon.authentication.AuthenticationException If the connection cannot be authenticated.
+     * @throws UnsupportedProtocolException if the protocol is not supported.
+     * @throws WagonConfigurationException if the wagon cannot be configured.
+     * @throws ConnectionException If the connection cannot be established.
+     * @throws AuthenticationException If the connection cannot be authenticated.
      */
     public static Wagon createWagon( String serverId, String url, WagonManager wagonManager, Settings settings,
                                      Log logger )


### PR DESCRIPTION
- Javadocs build on Java 1.8 without lint warnings
- Some Javadoc comments and tags cleaned up
- Javadocs for deprecated generated classes excluded from generation