### PR TITLE
Remove notice of deprecation for comparison rules

### DIFF
--- a/src/main/mdo/rule.mdo
+++ b/src/main/mdo/rule.mdo
@@ -27,8 +27,6 @@ under the License.
   <name>Rule</name>
   <description>
     A collection of version number comparison rules.
-    This is marked deprecated and will be removed with release 3.0.0 of the versions-maven-plugin.
-    If you are user of this please vote on &lt;a href="https://github.com/mojohaus/versions-maven-plugin/issues/157"&gt;issue #157&lt;/a&gt;
   </description>
   <defaults>
     <default>
@@ -43,7 +41,7 @@ under the License.
     <class xml.tagName="rule">
       <name>Rule</name>
       <description>
-        Describes a rule for how versions of artifacts should be handled. This is marked deprecated and will be removed with release 3.0.0 of the versions-maven-plugin.
+        Describes a rule for how versions of artifacts should be handled.
       </description>
       <version>1.0+</version>
       <fields>

--- a/src/site/apt/version-rules.apt.vm
+++ b/src/site/apt/version-rules.apt.vm
@@ -25,9 +25,6 @@
 
 Version number rules
 
-  This has been marked deprecated and will be removed with release 3.0.0 of the versions-maven-plugin.
-  If you are a user of this please vote on the {{{https://github.com/mojohaus/versions-maven-plugin/issues/157}issue #157}}.
-
 * Introduction
 
   <<Notice:>> The limitations explained in this paragraph were true in Maven 2.x, but have been <<fixed>> in Maven 3.x (see


### PR DESCRIPTION
As discussed in #157, custom rulesets will remain in 3.0.0.
This PR removes the no-longer-accurate deprecation warnings.

Closes #157.