### PR TITLE
Respect the processParent setting by introducing a new base class

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -22,11 +22,19 @@
     is not compatible with project minimum version, not really a proposed
     upgrade
 
- * [Fixed Issue 237][issue-237]
+ * [Fixed Issue 237][issue-237] and [Fixed Issue 288][issue-288]
 
-   Thanks to Julian Di Leonardo <DiJu519@users.noreply.github.com>
+   Thanks to Julian Di Leonardo <DiJu519@users.noreply.github.com> and [Adam Voss](https://github.com/adamvoss)
 
-   Adding parent processing to UseLatestVersion/UseLatestSnapshot/UseLatestRelease
+   Added parent processing to:
+     - UseLatestVersion
+     - UseLatestSnapshot
+     - UseLatestRelease
+     - ForceReleases
+     - UseDepVersion
+     - UseNextReleases
+     - UseNextSnapshots
+     - UseNextVersions
 
  * [Fixed Issue 190][issue-190]
 
@@ -153,6 +161,7 @@
 [issue-198]: https://github.com/mojohaus/versions-maven-plugin/issues/198
 [issue-237]: https://github.com/mojohaus/versions-maven-plugin/issues/237
 [issue-256]: https://github.com/mojohaus/versions-maven-plugin/issues/256
+[issue-288]: https://github.com/mojohaus/versions-maven-plugin/issues/288
 
 [pull-189]: https://github.com/mojohaus/versions-maven-plugin/pull/189
 [pull-252]: https://github.com/mojohaus/versions-maven-plugin/pull/252

--- a/src/it/it-use-next-releases-005/invoker.properties
+++ b/src/it/it-use-next-releases-005/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-releases

--- a/src/it/it-use-next-releases-005/pom.xml
+++ b/src/it/it-use-next-releases-005/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-005</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a parent dependency</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-impl</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <processParent>true</processParent>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-use-next-releases-005/verify.bsh
+++ b/src/it/it-use-next-releases-005/verify.bsh
@@ -1,0 +1,33 @@
+import java.io.*;
+import java.util.regex.*;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+
+    BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    StringBuilder buf = new StringBuilder();
+    String line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    Pattern p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*2\\.0\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    Matcher m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent to version 2.0" );
+        return false;
+    }
+    System.out.println( m.group( 0 ) );
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/ParentUpdatingDependencyUpdateMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ParentUpdatingDependencyUpdateMojo.java
@@ -1,0 +1,78 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public abstract class ParentUpdatingDependencyUpdateMojo extends AbstractVersionsDependencyUpdaterMojo
+{
+    /**
+     * @param pom the pom to update.
+     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
+     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
+     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
+     */
+    protected void update( ModifiedPomXMLEventReader pom )
+       throws MojoExecutionException, MojoFailureException, XMLStreamException
+    {
+        try
+        {
+            if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
+            {
+                setVersions( pom, getProject().getDependencyManagement().getDependencies() );
+            }
+            if ( getProject().getDependencies() != null && isProcessingDependencies() )
+            {
+                setVersions( pom, getProject().getDependencies() );
+            }
+            if ( getProject().getParent() != null && isProcessingParent() )
+            {
+                final Dependency dependency = new Dependency();
+                dependency.setArtifactId(getProject().getParent().getArtifactId());
+                dependency.setGroupId(getProject().getParent().getGroupId());
+                dependency.setVersion(getProject().getParent().getVersion());
+                dependency.setType("pom");
+                setVersions( pom, Collections.singleton(dependency));
+            }
+        }
+        catch ( ArtifactMetadataRetrievalException e )
+        {
+            throw new MojoExecutionException( e.getMessage(), e );
+        }
+    }
+
+    protected abstract void setVersions(ModifiedPomXMLEventReader pom, Collection<Dependency> dependencies)
+            throws ArtifactMetadataRetrievalException, XMLStreamException, MojoExecutionException;
+
+    protected void setVersion(ModifiedPomXMLEventReader pom, Dependency dep, String version, Artifact artifact, ArtifactVersion artifactVersion) throws XMLStreamException
+    {
+        final String newVersion = artifactVersion.toString();
+        if(getProject().getParent() != null){
+            if(artifact.getId().equals(getProject().getParentArtifact().getId()) && isProcessingParent())
+            {
+                if ( PomHelper.setProjectParentVersion( pom, newVersion.toString() ) )
+                {
+                    getLog().debug( "Made parent change from " + version + " to " + newVersion.toString() );
+                }
+            }
+        }
+
+        if ( PomHelper.setDependencyVersion( pom, dep.getGroupId(), dep.getArtifactId(), version,
+                                             newVersion, getProject().getModel() ) )
+        {
+            getLog().info( "Changed " + toString( dep ) + " to version " + newVersion );
+        }
+    }
+}


### PR DESCRIPTION
Respect the `processParent` setting by introducing a new base class.

Fixes #288 (`UseNextReleasesMojo`).  Also, fixes an analogous  bug in `ForceReleasesMojo`, `UseDepVersionMojo`, `UseNextReleasesMojo`, `UseNextSnapshotsMojo`, and `UseNextVersionsMojo`

The other existing Mojos that were not modified have their own parent-handling functionality except for `CompareDependenciesMojo` and  `UpdatePropertiesMojo` where the setting still has no effect.