### PR TITLE
Non default versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,12 @@
       <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/it-repo/test/bigversion/dummy-lib-1.1.1.1.jar
+++ b/src/it-repo/test/bigversion/dummy-lib-1.1.1.1.jar
@@ -1,0 +1,1 @@
+JAR File

--- a/src/it-repo/test/bigversion/dummy-lib-1.1.1.1.pom
+++ b/src/it-repo/test/bigversion/dummy-lib-1.1.1.1.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test.bigversion</groupId>
+  <artifactId>dummy-lib</artifactId>
+  <version>1.1.1.1</version>
+  <packaging>jar</packaging>
+
+</project>

--- a/src/it-repo/test/bigversion/dummy-lib-2.0.0.0.jar
+++ b/src/it-repo/test/bigversion/dummy-lib-2.0.0.0.jar
@@ -1,0 +1,1 @@
+JAR File

--- a/src/it-repo/test/bigversion/dummy-lib-2.0.0.0.pom
+++ b/src/it-repo/test/bigversion/dummy-lib-2.0.0.0.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test.bigversion</groupId>
+  <artifactId>dummy-lib</artifactId>
+  <version>2.0.0.0</version>
+  <packaging>jar</packaging>
+
+</project>

--- a/src/it-repo/test/bigversion/dummy-lib-2.0.10.0.jar
+++ b/src/it-repo/test/bigversion/dummy-lib-2.0.10.0.jar
@@ -1,0 +1,1 @@
+JAR File

--- a/src/it-repo/test/bigversion/dummy-lib-2.0.10.0.pom
+++ b/src/it-repo/test/bigversion/dummy-lib-2.0.10.0.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test.bigversion</groupId>
+  <artifactId>dummy-lib</artifactId>
+  <version>2.0.10.0</version>
+  <packaging>jar</packaging>
+
+</project>

--- a/src/it-repo/test/bigversion/dummy-lib-2.12.0.0.jar
+++ b/src/it-repo/test/bigversion/dummy-lib-2.12.0.0.jar
@@ -1,0 +1,1 @@
+JAR File

--- a/src/it-repo/test/bigversion/dummy-lib-2.12.0.0.pom
+++ b/src/it-repo/test/bigversion/dummy-lib-2.12.0.0.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test.bigversion</groupId>
+  <artifactId>dummy-lib</artifactId>
+  <version>2.12.0.0</version>
+  <packaging>jar</packaging>
+
+</project>

--- a/src/it-repo/test/bigversion/dummy-lib-3.0.0.0-SNAPSHOT.jar
+++ b/src/it-repo/test/bigversion/dummy-lib-3.0.0.0-SNAPSHOT.jar
@@ -1,0 +1,1 @@
+JAR File

--- a/src/it-repo/test/bigversion/dummy-lib-3.0.0.0-SNAPSHOT.pom
+++ b/src/it-repo/test/bigversion/dummy-lib-3.0.0.0-SNAPSHOT.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test.bigversion</groupId>
+  <artifactId>dummy-lib</artifactId>
+  <version>3.0.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+</project>

--- a/src/it/it-use-latest-versions-012/invoker.properties
+++ b/src/it/it-use-latest-versions-012/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-versions

--- a/src/it/it-use-latest-versions-012/pom.xml
+++ b/src/it/it-use-latest-versions-012/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent3</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-versions-012</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update dependency with a version that does not conform to major.minor.increment-qualifier</name>
+  <url>https://github.com/mojohaus/versions-maven-plugin/issues/304</url>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>test.bigversion</groupId>
+      <artifactId>dummy-lib</artifactId>
+      <version>2.0.0.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-use-latest-versions-012/verify.bsh
+++ b/src/it/it-use-latest-versions-012/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>2.12.0.0</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-lib not bumped to 2.12.0.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/ordering/MajorMinorIncrementalFilter.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/MajorMinorIncrementalFilter.java
@@ -106,22 +106,11 @@ public class MajorMinorIncrementalFilter
                     }
                 }
             }
-            else if(selectedVersion.getQualifier() != null){
-                if(selectedVersion.getQualifier().contentEquals("SNAPSHOT")){
-                    if ( !versionsToUse.contains( artifactVersion ) )
-                    {
-                            versionsToUse.add( artifactVersion );
-                    }
-                }
-            }
-            else
-            {
-                if ( allowMajorUpdates && allowMinorUpdates && allowIncrementalUpdates )
+            else {
+                // build number or qualifier.  Will already be sorted and higher
+                if ( !versionsToUse.contains( artifactVersion ) )
                 {
-                    if ( !versionsToUse.contains( artifactVersion ) )
-                    {
                         versionsToUse.add( artifactVersion );
-                    }
                 }
             }
         }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/MajorMinorIncrementalFilterTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/MajorMinorIncrementalFilterTest.java
@@ -1,0 +1,94 @@
+package org.codehaus.mojo.versions.ordering;
+
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.junit.Test;
+
+import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
+import static org.junit.Assert.assertThat;
+
+public class MajorMinorIncrementalFilterTest {
+
+    private ArtifactVersion[] newerVersions = new ArtifactVersion[] { version("1.1.1-sp1"),
+                                                                      version("1.1.1-1"),
+                                                                      version("1.1.2"),
+                                                                      version("1.1.3"),
+                                                                      version("1.2.0"),
+                                                                      version("2.0.0-SNAPSHOT") };
+
+    @Test
+    public void checkFilter() {
+        ArtifactVersion selectedVersion = version("1.1.1");
+        MajorMinorIncrementalFilter filter = new MajorMinorIncrementalFilter(true, true, true);
+        ArtifactVersion[] filteredVersions = filter.filter(selectedVersion, newerVersions);
+        assertThat(filteredVersions,
+                   arrayContaining(version("1.1.1-sp1"), version("1.1.1-1"),
+                                   version("1.1.2"), version("1.1.3"),
+                                   version("1.2.0"), version("2.0.0-SNAPSHOT")));
+    }
+
+    @Test
+    public void checkFilterWithNoMajorUpdates() {
+        ArtifactVersion selectedVersion = version("1.1.1");
+        MajorMinorIncrementalFilter filter = new MajorMinorIncrementalFilter(false, true, true);
+        ArtifactVersion[] filteredVersions = filter.filter(selectedVersion, newerVersions);
+        assertThat(filteredVersions, arrayContaining(version("1.1.1-sp1"), version("1.1.1-1"),
+                                                     version("1.1.2"), version("1.1.3"), version("1.2.0")));
+    }
+
+    @Test
+    public void checkFilterWithNoMajorOrMinorUpdates() {
+        ArtifactVersion selectedVersion = version("1.1.1");
+        MajorMinorIncrementalFilter filter = new MajorMinorIncrementalFilter(false, false, true);
+        ArtifactVersion[] filteredVersions = filter.filter(selectedVersion, newerVersions);
+        assertThat(filteredVersions, arrayContaining(version("1.1.1-sp1"), version("1.1.1-1"),
+                                                     version("1.1.2"), version("1.1.3")));
+    }
+
+    @Test
+    public void checkFilterWithNoMajorOrMinorOrIncrementalUpdates() {
+        ArtifactVersion selectedVersion = version("1.1.1");
+        MajorMinorIncrementalFilter filter = new MajorMinorIncrementalFilter(false, false, false);
+        ArtifactVersion[] filteredVersions = filter.filter(selectedVersion, newerVersions);
+        assertThat(filteredVersions, arrayContaining(version("1.1.1-sp1"), version("1.1.1-1")));
+    }
+
+    @Test
+    public void checkFilterWithSnapshotAtSameVersion() {
+        ArtifactVersion selectedVersion = version("1.1.1-SNAPSHOT");
+        MajorMinorIncrementalFilter filter = new MajorMinorIncrementalFilter(false, false, false);
+        ArtifactVersion[] filteredVersions = filter.filter(selectedVersion,
+                                                           new ArtifactVersion[] {version("1.1.1")});
+        assertThat(filteredVersions, arrayContaining(version("1.1.1")));
+    }
+
+
+    @Test
+    public void checkFilterWithNonStandardVersions() {
+        ArtifactVersion selectedVersion = version("1.1.1.1");
+        MajorMinorIncrementalFilter filter = new MajorMinorIncrementalFilter(true, true, true);
+
+        ArtifactVersion[] newerVersions = new ArtifactVersion[] { version("1.1.1.1-sp1"),
+                                                                  version("1.1.1.2"),
+                                                                  version("1.1.2.21"),
+                                                                  version("1.1.3.0"),
+                                                                  version("1.2.0"),
+                                                                  version("1.2.0.1"),
+                                                                  version("2.0.0-SNAPSHOT") };
+
+
+        ArtifactVersion[] filteredVersions = filter.filter(selectedVersion, newerVersions);
+        assertThat(filteredVersions,
+                   arrayContaining(version("1.1.1.1-sp1"),
+                                   version("1.1.1.2"),
+                                   version("1.1.2.21"),
+                                   version("1.1.3.0"),
+                                   version("1.2.0"),
+                                   version("1.2.0.1"),
+                                   version("2.0.0-SNAPSHOT")));
+    }
+
+    private ArtifactVersion version(String versionString) {
+        return new DefaultArtifactVersion(versionString);
+    }
+}


### PR DESCRIPTION
Fixes the incorrect logic in the `MajorMinorIncrementalFilter` that caused numerous issues.

Fixes #304 for which tests are included and this was targetted.

I also beleive (and there is some minimal test for it) #296 #295 #282 

ITs pass on maven `3.5.2`  as the ordering and parsing relies on some fixes in Maven 3.x they may or may not pass on maven 2.x.

@stephenc @khmarbaise @olamy 