### PR TITLE
Fixed #313 -add runOnlyAtExecutionRoot

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -529,14 +529,7 @@ public class SetMojo
         log.debug("Root Folder:" + session.getExecutionRootDirectory());
         log.debug("Current Folder:"+ basedir );
         boolean result = session.getExecutionRootDirectory().equalsIgnoreCase(basedir.toString());
-        if (result)
-        {
-            log.debug( "This is the execution root." );
-        }
-        else
-        {
-            log.debug( "This is NOT the execution root." );
-        }
+        log.debug( "This is the execution root?" + result);
         return result;
     }
 


### PR DESCRIPTION
This pull request is to allow a property (runOnlyAtExecutionRoot) to be set that will cause the assembly to run only at the top of a given module tree. That is, run in the project contained in the same folder where the mvn execution was launched.