### PR TITLE
Fix #250 NPE when dependencyManagement lacks a version

### DIFF
--- a/src/it/it-use-latest-releases-001-issue-250/invoker.properties
+++ b/src/it/it-use-latest-releases-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases

--- a/src/it/it-use-latest-releases-001-issue-250/pom.xml
+++ b/src/it/it-use-latest-releases-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-releases-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the latest release version, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-latest-releases-001-issue-250/verify.bsh
+++ b/src/it/it-use-latest-releases-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>3.0</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-snapshots-001-issue-250/invoker.properties
+++ b/src/it/it-use-latest-snapshots-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-snapshots -DallowMinorUpdates=true

--- a/src/it/it-use-latest-snapshots-001-issue-250/pom.xml
+++ b/src/it/it-use-latest-snapshots-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-snapshots-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a release dependency to the latest snapshot version, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-latest-snapshots-001-issue-250/verify.bsh
+++ b/src/it/it-use-latest-snapshots-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.9.1-SNAPSHOT</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 1.9.1-SNAPSHOT" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-versions-001-issue-250/invoker.properties
+++ b/src/it/it-use-latest-versions-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-versions

--- a/src/it/it-use-latest-versions-001-issue-250/pom.xml
+++ b/src/it/it-use-latest-versions-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-versions-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-latest-versions-001-issue-250/verify.bsh
+++ b/src/it/it-use-latest-versions-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>3.0</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 3.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-releases-001-issue-250/invoker.properties
+++ b/src/it/it-use-next-releases-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-releases

--- a/src/it/it-use-next-releases-001-issue-250/pom.xml
+++ b/src/it/it-use-next-releases-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-next-releases-001-issue-250/verify.bsh
+++ b/src/it/it-use-next-releases-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.1.2</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 1.1.2" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-snapshots-001-issue-250/invoker.properties
+++ b/src/it/it-use-next-snapshots-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-snapshots

--- a/src/it/it-use-next-snapshots-001-issue-250/pom.xml
+++ b/src/it/it-use-next-snapshots-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-snapshots-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a release dependency to the next snapshot version, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-next-snapshots-001-issue-250/verify.bsh
+++ b/src/it/it-use-next-snapshots-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.1.2-SNAPSHOT</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 1.1.2-SNAPSHOT" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-versions-001-issue-250/invoker.properties
+++ b/src/it/it-use-next-versions-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-versions

--- a/src/it/it-use-next-versions-001-issue-250/pom.xml
+++ b/src/it/it-use-next-versions-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-versions-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next versions, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-next-versions-001-issue-250/verify.bsh
+++ b/src/it/it-use-next-versions-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.1.2</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api not bumped to 1.1.2" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-releases-001-issue-250/invoker.properties
+++ b/src/it/it-use-releases-001-issue-250/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-releases

--- a/src/it/it-use-releases-001-issue-250/pom.xml
+++ b/src/it/it-use-releases-001-issue-250/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-releases-001-issue-250</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version, ignore dependency without version in dependencyManagement</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <!-- assume an exclusion list here -->
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-use-releases-001-issue-250/verify.bsh
+++ b/src/it/it-use-releases-001-issue-250/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.1.1-2</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-api bumped" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -19,11 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
@@ -500,4 +496,15 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
         return nextRangeStartDelimiterIndex;
     }
 
+    protected List<Dependency> filterDependenciesWithoutVersion(List<Dependency> dependencies) {
+        final ArrayList<Dependency> result = new ArrayList<>();
+        for (Dependency dep: dependencies) {
+            if (null == dep.getVersion()) {
+                getLog().info("Dependency without version will be ignored: " + toString(dep));
+                continue;
+            }
+            result.add(dep);
+        }
+        return result;
+    }
 }

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -37,10 +37,7 @@ import org.codehaus.mojo.versions.ordering.MajorMinorIncrementalFilter;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 import javax.xml.stream.XMLStreamException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -102,7 +99,7 @@ public class UseLatestReleasesMojo
         {
             if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
             {
-                useLatestReleases( pom, getProject().getDependencyManagement().getDependencies() );
+                useLatestReleases( pom, filterDependenciesWithoutVersion(getProject().getDependencyManagement().getDependencies()) );
             }
             if ( getProject().getDependencies() != null && isProcessingDependencies() )
             {
@@ -142,6 +139,7 @@ public class UseLatestReleasesMojo
             }
 
             String version = dep.getVersion();
+            Objects.requireNonNull(version, "Dependency without version: " + toString(dep));
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( !versionMatcher.matches() )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -35,11 +35,7 @@ import org.codehaus.mojo.versions.ordering.VersionComparator;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 import javax.xml.stream.XMLStreamException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -101,7 +97,7 @@ public class UseLatestSnapshotsMojo
         {
             if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
             {
-                useLatestSnapshots( pom, getProject().getDependencyManagement().getDependencies() );
+                useLatestSnapshots( pom, filterDependenciesWithoutVersion(getProject().getDependencyManagement().getDependencies()) );
             }
             if ( getProject().getDependencies() != null && isProcessingDependencies() )
             {
@@ -141,6 +137,7 @@ public class UseLatestSnapshotsMojo
             }
 
             String version = dep.getVersion();
+            Objects.requireNonNull(version, "Dependency without version: " + toString(dep));
             Matcher versionMatcher = matchSnapshotRegex.matcher(version);
             if ( !versionMatcher.matches() )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -20,10 +20,7 @@ package org.codehaus.mojo.versions;
  */
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -96,7 +93,7 @@ public class UseLatestVersionsMojo
                     PomHelper.getRawModel( getProject() ).getDependencyManagement();
                 if ( dependencyManagement != null )
                 {
-                    useLatestVersions( pom, dependencyManagement.getDependencies() );
+                    useLatestVersions( pom, filterDependenciesWithoutVersion(dependencyManagement.getDependencies()) );
                 }
             }
             if ( getProject().getDependencies() != null && isProcessingDependencies() )
@@ -141,6 +138,7 @@ public class UseLatestVersionsMojo
             }
 
             String version = dep.getVersion();
+            Objects.requireNonNull(version, "Dependency without version: " + toString(dep));
             Artifact artifact = this.toArtifact( dep );
             if ( !isIncluded( artifact ) )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -32,7 +32,7 @@ import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,7 +68,7 @@ public class UseNextReleasesMojo
     {
         if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
         {
-            useNextReleases( pom, getProject().getDependencyManagement().getDependencies() );
+            useNextReleases( pom, filterDependenciesWithoutVersion(getProject().getDependencyManagement().getDependencies()) );
         }
         if ( getProject().getDependencies() != null && isProcessingDependencies() )
         {
@@ -88,6 +88,7 @@ public class UseNextReleasesMojo
             }
 
             String version = dep.getVersion();
+            Objects.requireNonNull(version, "Dependency without version: " + toString(dep));
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( !versionMatcher.matches() )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -36,7 +36,7 @@ import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -98,7 +98,7 @@ public class UseNextSnapshotsMojo
         {
             if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
             {
-                useNextSnapshots( pom, getProject().getDependencyManagement().getDependencies() );
+                useNextSnapshots( pom, filterDependenciesWithoutVersion(getProject().getDependencyManagement().getDependencies()) );
             }
             if ( getProject().getDependencies() != null && isProcessingDependencies() )
             {
@@ -125,6 +125,7 @@ public class UseNextSnapshotsMojo
             }
 
             String version = dep.getVersion();
+            Objects.requireNonNull(version, "Dependency without version: " + toString(dep));
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( !versionMatcher.matches() )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
@@ -32,7 +32,7 @@ import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * Replaces any version with the latest version.
@@ -61,7 +61,7 @@ public class UseNextVersionsMojo
         {
             if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
             {
-                useNextVersions( pom, getProject().getDependencyManagement().getDependencies() );
+                useNextVersions( pom, filterDependenciesWithoutVersion(getProject().getDependencyManagement().getDependencies()) );
             }
             if ( getProject().getDependencies() != null && isProcessingDependencies() )
             {
@@ -85,6 +85,7 @@ public class UseNextVersionsMojo
             }
 
             String version = dep.getVersion();
+            Objects.requireNonNull(version, "Dependency without version: " + toString(dep));
             Artifact artifact = this.toArtifact( dep );
             if ( !isIncluded( artifact ) )
             {

--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -96,8 +96,8 @@ public class UseReleasesMojo
 
             if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
             {
-                useReleases( pom, PomHelper.readImportedPOMsFromDependencyManagementSection( pom ) );
-                useReleases( pom, getProject().getDependencyManagement().getDependencies() );
+                useReleases( pom, filterDependenciesWithoutVersion(PomHelper.readImportedPOMsFromDependencyManagementSection( pom )) );
+                useReleases( pom, filterDependenciesWithoutVersion(getProject().getDependencyManagement().getDependencies()) );
             }
             if ( getProject().getDependencies() != null && isProcessingDependencies() )
             {

--- a/src/test/java/org/codehaus/mojo/versions/UseNextSnapshotsMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/UseNextSnapshotsMojoTest.java
@@ -1,0 +1,112 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.api.VersionsHelper;
+import org.codehaus.mojo.versions.ordering.MavenVersionComparator;
+import org.codehaus.mojo.versions.ordering.VersionComparator;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.xml.stream.XMLStreamException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class UseNextSnapshotsMojoTest {
+    @Mock
+    private MavenProject mavenProject;
+    @Mock
+    private ModifiedPomXMLEventReader pom;
+    @Mock
+    private DependencyManagement dependencyManagement;
+    @Mock
+    private Dependency dependency;
+    @Mock
+    private VersionsHelper versionsHelper;
+    @Mock
+    private Artifact artifact;
+    @Mock
+    private Model model;
+
+    private UseNextSnapshotsMojo useNextSnapshotsMojo;
+
+    private final String currentVersion = "1.2.3";
+    private final String snapshotVersion = "1.2.4-SNAPSHOT";
+
+    @Before
+    public void setUp() throws Exception {
+        useNextSnapshotsMojo = new UseNextSnapshotsMojo();
+        useNextSnapshotsMojo.project = mavenProject;
+        setProperty(AbstractVersionsUpdaterMojo.class, "helper", versionsHelper);
+        when(mavenProject.getModel()).thenReturn(model);
+        when(model.getProperties()).thenReturn(new Properties());
+        VersionComparator versionComparator = new MavenVersionComparator();
+        when(mavenProject.getDependencyManagement()).thenReturn(dependencyManagement);
+        when(dependencyManagement.getDependencies()).thenReturn(Collections.singletonList(dependency));
+        final List<ArtifactVersion> artifactVersionList = Arrays.asList((ArtifactVersion) new DefaultArtifactVersion(currentVersion),
+                new DefaultArtifactVersion(snapshotVersion));
+        final ArtifactVersions artifactVersions = new ArtifactVersions(artifact, artifactVersionList, versionComparator);
+        when(versionsHelper.lookupArtifactVersions(any(Artifact.class), anyBoolean())).thenReturn(artifactVersions);
+    }
+
+    @Test
+    public void update() throws MojoFailureException, XMLStreamException, MojoExecutionException {
+        useNextSnapshotsMojo.update(pom);
+    }
+
+    /**
+     * Cannot verify it any further than it doesn't throw any exceptions due to use of static PomHelper.setDependencyVersion
+     * @throws MojoFailureException
+     * @throws XMLStreamException
+     * @throws MojoExecutionException
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    @Test
+    public void updateWithDependencyManagement() throws MojoFailureException, XMLStreamException, MojoExecutionException, NoSuchFieldException, IllegalAccessException {
+        setProperty(AbstractVersionsDependencyUpdaterMojo.class, "processDependencyManagement", true);
+        when(dependency.getVersion()).thenReturn(currentVersion);
+        useNextSnapshotsMojo.update(pom);
+    }
+
+    /**
+     * Cannot verify it any further than it doesn't throw NPE due to use of static PomHelper.setDependencyVersion
+     * @throws MojoFailureException
+     * @throws XMLStreamException
+     * @throws MojoExecutionException
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    @Test
+    public void updateWithDependencyManagementWithoutVersion() throws MojoFailureException, XMLStreamException, MojoExecutionException, NoSuchFieldException, IllegalAccessException {
+        setProperty(AbstractVersionsDependencyUpdaterMojo.class, "processDependencyManagement", true);
+        useNextSnapshotsMojo.update(pom);
+    }
+
+    private <T> void setProperty(Class<? super UseNextSnapshotsMojo> mojoClass, String name, T value) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = mojoClass.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(useNextSnapshotsMojo, value);
+    }
+}


### PR DESCRIPTION
- Add integration tests for the reported issue.
- Dependencies without version in dependencyManagement will be logged and ignored.
- Dependencies without version will still fail, but will produce more informative message, stating which dependency caused the failure