### PR TITLE
Fixed #321

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -309,7 +309,7 @@ public abstract class AbstractVersionsUpdaterMojo
         try
         {
             StringBuilder input = PomHelper.readXmlFile( outFile );
-            ModifiedPomXMLEventReader newPom = newModifiedPomXER( input );
+            ModifiedPomXMLEventReader newPom = newModifiedPomXER( outFile.getAbsolutePath(), input );
 
             update( newPom );
 
@@ -353,17 +353,18 @@ public abstract class AbstractVersionsUpdaterMojo
     /**
      * Creates a {@link org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader} from a StringBuilder.
      *
+     * @param path The path of the file (for logging purposes)
      * @param input The XML to read and modify.
      * @return The {@link org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader}.
      */
-    protected final ModifiedPomXMLEventReader newModifiedPomXER( StringBuilder input )
+    protected final ModifiedPomXMLEventReader newModifiedPomXER( String path, StringBuilder input )
     {
         ModifiedPomXMLEventReader newPom = null;
         try
         {
             XMLInputFactory inputFactory = XMLInputFactory2.newInstance();
             inputFactory.setProperty( XMLInputFactory2.P_PRESERVE_LOCATION, Boolean.TRUE );
-            newPom = new ModifiedPomXMLEventReader( input, inputFactory );
+            newPom = new ModifiedPomXMLEventReader( input, inputFactory, path, getLog() );
         }
         catch ( XMLStreamException e )
         {

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -190,7 +190,7 @@ public class DisplayPluginUpdatesMojo
                         try( Reader reader = ReaderFactory.newXmlReader( superPom ) )
                         {
                             StringBuilder buf = new StringBuilder( IOUtil.toString( reader ) );
-                            ModifiedPomXMLEventReader pom = newModifiedPomXER( buf );
+                            ModifiedPomXMLEventReader pom = newModifiedPomXER( getProject().getFile().getAbsolutePath(), buf );
 
                             Pattern pathRegex = Pattern.compile( "/project(/profiles/profile)?"
                                 + "((/build(/pluginManagement)?)|(/reporting))" + "/plugins/plugin" );
@@ -769,7 +769,7 @@ public class DisplayPluginUpdatesMojo
                 try
                 {
                     Set<String> withVersionSpecified =
-                        findPluginsWithVersionsSpecified( new StringBuilder( writer.toString() ) );
+                        findPluginsWithVersionsSpecified( parentProject, new StringBuilder( writer.toString() ) );
 
                     Map<String, String> map = getPluginManagement( interpolatedModel );
                     map.keySet().retainAll( withVersionSpecified );
@@ -850,20 +850,21 @@ public class DisplayPluginUpdatesMojo
     private Set<String> findPluginsWithVersionsSpecified( MavenProject project )
         throws IOException, XMLStreamException
     {
-        return findPluginsWithVersionsSpecified( PomHelper.readXmlFile( project.getFile() ) );
+        return findPluginsWithVersionsSpecified( project, PomHelper.readXmlFile( project.getFile() ) );
     }
 
     /**
      * Returns a set of Strings which correspond to the plugin coordinates where there is a version specified.
      *
+     * @param project The Maven project (for logging purposes)
      * @param pomContents The project to get the plugins with versions specified.
      * @return a set of Strings which correspond to the plugin coordinates where there is a version specified.
      */
-    private Set<String> findPluginsWithVersionsSpecified( StringBuilder pomContents )
+    private Set<String> findPluginsWithVersionsSpecified( MavenProject project, StringBuilder pomContents )
         throws IOException, XMLStreamException
     {
         Set<String> result = new HashSet<>();
-        ModifiedPomXMLEventReader pom = newModifiedPomXER( pomContents );
+        ModifiedPomXMLEventReader pom = newModifiedPomXER( project.getFile().getAbsolutePath(), pomContents );
 
         Pattern pathRegex = Pattern.compile( "/project(/profiles/profile)?"
             + "((/build(/pluginManagement)?)|(/reporting))" + "/plugins/plugin" );

--- a/src/main/java/org/codehaus/mojo/versions/rewriting/ModifiedPomXMLEventReader.java
+++ b/src/main/java/org/codehaus/mojo/versions/rewriting/ModifiedPomXMLEventReader.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.versions.rewriting;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import javax.xml.stream.XMLEventReader;
@@ -119,6 +120,16 @@ public class ModifiedPomXMLEventReader
      */
     private XMLEventReader backing;
 
+    /**
+     * Field path
+     */
+    private String path;
+
+    /**
+     * Field log
+     */
+    private Log log;
+
     // --------------------------- CONSTRUCTORS ---------------------------
 
     /**
@@ -126,13 +137,17 @@ public class ModifiedPomXMLEventReader
      *
      * @param pom of type StringBuilder
      * @param factory of type XMLInputFactory
+     * @param path of the file being rewritten, for logging purposes
+     * @param log to log messages into
      * @throws XMLStreamException when
      */
-    public ModifiedPomXMLEventReader( StringBuilder pom, XMLInputFactory factory )
+    public ModifiedPomXMLEventReader( StringBuilder pom, XMLInputFactory factory, String path, Log log )
         throws XMLStreamException
     {
         this.pom = pom;
         this.factory = factory;
+        this.path = path;
+        this.log = log;
         rewind();
     }
 
@@ -374,6 +389,7 @@ public class ModifiedPomXMLEventReader
         }
         catch ( XMLStreamException e )
         {
+            log.error("Unable to parse pom.xml file at " + path, e);
             return false;
         }
     }

--- a/src/test/java/org/codehaus/mojo/versions/api/PomHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/api/PomHelperTest.java
@@ -3,9 +3,12 @@ package org.codehaus.mojo.versions.api;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.stax2.XMLInputFactory2;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.xml.stream.XMLInputFactory;
 import java.io.File;
@@ -24,6 +27,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class PomHelperTest
 {
+    private Log log;
+
     /**
      * Tests if imported POMs are properly read from dependency management section. Such logic is required to resolve
      * <a href="https://github.com/mojohaus/versions-maven-plugin/issues/134">bug #134</a>
@@ -40,7 +45,7 @@ public class PomHelperTest
         XMLInputFactory inputFactory = XMLInputFactory2.newInstance();
         inputFactory.setProperty( XMLInputFactory2.P_PRESERVE_LOCATION, Boolean.TRUE );
 
-        ModifiedPomXMLEventReader pom = new ModifiedPomXMLEventReader( input, inputFactory );
+        ModifiedPomXMLEventReader pom = new ModifiedPomXMLEventReader( input, inputFactory, "test", log );
 
         List<Dependency> dependencies = PomHelper.readImportedPOMsFromDependencyManagementSection( pom );
 
@@ -70,7 +75,7 @@ public class PomHelperTest
         XMLInputFactory inputFactory = XMLInputFactory2.newInstance();
         inputFactory.setProperty( XMLInputFactory2.P_PRESERVE_LOCATION, Boolean.TRUE );
 
-        ModifiedPomXMLEventReader pom = new ModifiedPomXMLEventReader( input, inputFactory );
+        ModifiedPomXMLEventReader pom = new ModifiedPomXMLEventReader( input, inputFactory, "test", log );
 
         String oldVersion = PomHelper.getProjectVersion( pom );
 
@@ -181,6 +186,12 @@ public class PomHelperTest
     {
         assertTrue( PomHelper.isVersionOverlap( "[1.0.0,2.0.0]", "1.0.8" ) );
 
+    }
+
+    @Before
+    public void setup()
+    {
+        log = Mockito.mock(Log.class);
     }
 
 }


### PR DESCRIPTION
* ModifiedPomXMLEventReader now takes a path and Log object
* If an error is encountered during parsing, a message is logged