### PR TITLE
Ensure display output is order, only order at point of printing

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -574,7 +574,7 @@ public class DisplayPluginUpdatesMojo
         else
         {
             logLine( false, "The following plugin updates are available:" );
-            for ( String update : pluginUpdates )
+            for ( String update : new TreeSet<>(pluginUpdates) )
             {
                 logLine( false, update );
             }
@@ -589,7 +589,7 @@ public class DisplayPluginUpdatesMojo
         else
         {
             getLog().warn( "The following plugins do not have their version specified:" );
-            for ( String lockdown : pluginLockdowns )
+            for ( String lockdown : new TreeSet<>(pluginLockdowns) )
             {
                 getLog().warn( lockdown );
             }

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -22,6 +22,7 @@ package org.codehaus.mojo.versions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -180,7 +181,7 @@ public class DisplayPropertyUpdatesMojo
         if ( !current.isEmpty() )
         {
             logLine( false, "The following version properties are referencing the newest available version:" );
-            for ( String s : current )
+            for ( String s : new TreeSet<>(current) )
             {
                 logLine( false, "  " + s );
             }
@@ -197,7 +198,7 @@ public class DisplayPropertyUpdatesMojo
         if ( !updates.isEmpty() )
         {
             logLine( false, "The following version property updates are available:" );
-            for ( String update : updates )
+            for ( String update : new TreeSet<>(updates) )
             {
                 logLine( false, "  " + update );
             }


### PR DESCRIPTION
I often have to redirect the output into a log file and compare with another project or branch. The output can vary depending as the dependency tree and multi-module project tree changes.

This is the simple version as it only orders the output when printing, instead of doing a wider change and correctly the main collection being used to a SortedSet, as List which currently is used doesn't make sense for me.