### PR TITLE
Fix for #340.

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -183,6 +183,18 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
     }
 
     /**
+     * Should the dependency be updated itself or is it handled by properties.
+     * 
+     * @param dependency
+     * @return true if the version starts with '${'
+     * @since 2.8
+     */
+    protected boolean isHandledByProperty(Dependency dependency) {
+		String version = dependency.getVersion();
+		return version.startsWith("${");
+	}
+
+    /**
      * Try to find the dependency artifact that matches the given dependency.
      *
      * @param dependency

--- a/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
@@ -94,6 +94,12 @@ public class ForceReleasesMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( versionMatcher.matches() )

--- a/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
@@ -93,6 +93,12 @@ public class LockSnapshotsMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             if ( !isIncluded( this.toArtifact( dep ) ) )
             {
                 continue;

--- a/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -214,6 +214,12 @@ public class ResolveRangesMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             Matcher versionMatcher = matchRangeRegex.matcher( dep.getVersion() );
 
             if ( versionMatcher.find() )

--- a/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
@@ -92,6 +92,12 @@ public class UnlockSnapshotsMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             if ( !isIncluded( this.toArtifact( dep ) ) )
             {
                 continue;

--- a/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -102,6 +102,12 @@ public class UseDepVersionMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             Artifact artifact = this.toArtifact( dep );
 
             if ( isIncluded( artifact ) )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -141,6 +141,12 @@ public class UseLatestReleasesMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( !versionMatcher.matches() )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -140,6 +140,12 @@ public class UseLatestSnapshotsMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Matcher versionMatcher = matchSnapshotRegex.matcher(version);
             if ( !versionMatcher.matches() )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -140,6 +140,12 @@ public class UseLatestVersionsMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Artifact artifact = this.toArtifact( dep );
             if ( !isIncluded( artifact ) )

--- a/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -87,6 +87,12 @@ public class UseNextReleasesMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( !versionMatcher.matches() )

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -124,6 +124,12 @@ public class UseNextSnapshotsMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( !versionMatcher.matches() )

--- a/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
@@ -84,6 +84,12 @@ public class UseNextVersionsMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Artifact artifact = this.toArtifact( dep );
             if ( !isIncluded( artifact ) )

--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -202,6 +202,12 @@ public class UseReleasesMojo
                 continue;
             }
 
+            if ( isHandledByProperty( dep ) )
+            {
+                getLog().debug( "Ignoring dependency with property as version: " + toString( dep ) );
+                continue;
+            }
+
             String version = dep.getVersion();
             Matcher versionMatcher = matchSnapshotRegex.matcher( version );
             if ( versionMatcher.matches() )


### PR DESCRIPTION
#340 issue in short: property versions are overwritten with actual versions instead of leaving them alone.

Also ran into this problem, fixed it by adding an ignore for versions that start with the '${' property reference announcer.

Added it everywhere I also saw the following bit of code that skipped the reactor dependencies:

```
            if ( isExcludeReactor() && isProducedByReactor( dep ) )
            {
                getLog().info( "Ignoring reactor dependency: " + toString( dep ) );
                continue;
            }
```

see also https://github.com/mojohaus/versions-maven-plugin/issues/340