### PR TITLE
Changerecorder

### DIFF
--- a/src/it/it-changerecord-update-parent-001/invoker.properties
+++ b/src/it/it-changerecord-update-parent-001/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:update-parent

--- a/src/it/it-changerecord-update-parent-001/pom.xml
+++ b/src/it/it-changerecord-update-parent-001/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-201</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-parent basic test</name>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/it-changerecord-update-parent-001/verify.bsh
+++ b/src/it/it-changerecord-update-parent-001/verify.bsh
@@ -1,0 +1,22 @@
+import java.io.*;
+import java.util.regex.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/versions-changes.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<update artifactId=\"dummy-parent\" groupId=\"localhost\" kind=\"updateParent\" newVersion=\"3.0\" oldVersion=\"1.0\"/>" ) < 0 )
+    {
+        System.err.println( "Version change recorded" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-changerecord-update-properties-001/invoker.properties
+++ b/src/it/it-changerecord-update-properties-001/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:update-properties

--- a/src/it/it-changerecord-update-properties-001/pom.xml
+++ b/src/it/it-changerecord-update-properties-001/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>update-properties with one property only</name>
+
+  <properties>
+    <api>1.0</api>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <properties>
+            <property>
+              <name>api</name>
+              <dependencies>
+                <dependency>
+                  <groupId>localhost</groupId>
+                  <artifactId>dummy-api</artifactId>
+                </dependency>
+              </dependencies>
+            </property>
+          </properties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-changerecord-update-properties-001/verify.bsh
+++ b/src/it/it-changerecord-update-properties-001/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/versions-changes.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<update artifactId=\"dummy-api\" groupId=\"localhost\" kind=\"updateProperty\" newVersion=\"3.0\" oldVersion=\"1.0\"/>" ) < 0 )
+    {
+        System.err.println( "Version change recorded" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-changerecord-use-latest-releases-001/invoker.properties
+++ b/src/it/it-changerecord-use-latest-releases-001/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases

--- a/src/it/it-changerecord-use-latest-releases-001/pom.xml
+++ b/src/it/it-changerecord-use-latest-releases-001/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-releases-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the latest release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-changerecord-use-latest-releases-001/verify.bsh
+++ b/src/it/it-changerecord-use-latest-releases-001/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/versions-changes.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<update artifactId=\"dummy-api\" groupId=\"localhost\" kind=\"useLatestReleases\" newVersion=\"3.0\" oldVersion=\"1.1.1-2\"/>" ) < 0 )
+    {
+        System.err.println( "Version change recorded" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-changerecord-use-latest-snapshots-001/invoker.properties
+++ b/src/it/it-changerecord-use-latest-snapshots-001/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:use-latest-snapshots -DallowMinorUpdates=true

--- a/src/it/it-changerecord-use-latest-snapshots-001/pom.xml
+++ b/src/it/it-changerecord-use-latest-snapshots-001/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-snapshots-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a release dependency to the latest snapshot version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-changerecord-use-latest-snapshots-001/verify.bsh
+++ b/src/it/it-changerecord-use-latest-snapshots-001/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/versions-changes.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<update artifactId=\"dummy-api\" groupId=\"localhost\" kind=\"useLatestSnapshots\" newVersion=\"1.9.1-SNAPSHOT\" oldVersion=\"1.0\"/>" ) < 0 )
+    {
+        System.err.println( "Version change recorded" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-changerecord-use-latest-versions-001/invoker.properties
+++ b/src/it/it-changerecord-use-latest-versions-001/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:use-latest-versions

--- a/src/it/it-changerecord-use-latest-versions-001/pom.xml
+++ b/src/it/it-changerecord-use-latest-versions-001/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-versions-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next release version</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-changerecord-use-latest-versions-001/verify.bsh
+++ b/src/it/it-changerecord-use-latest-versions-001/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/versions-changes.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<update artifactId=\"dummy-api\" groupId=\"localhost\" kind=\"useLatestVersions\" newVersion=\"3.0\" oldVersion=\"1.1.1-2\"/>" ) < 0 )
+    {
+        System.err.println( "Version change recorded" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-changerecord-use-next-versions-001/invoker.properties
+++ b/src/it/it-changerecord-use-next-versions-001/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:use-next-versions

--- a/src/it/it-changerecord-use-next-versions-001/pom.xml
+++ b/src/it/it-changerecord-use-next-versions-001/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-versions-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the next versions</name>
+
+  <dependencies>
+        
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+    
+  </dependencies>
+
+</project>

--- a/src/it/it-changerecord-use-next-versions-001/verify.bsh
+++ b/src/it/it-changerecord-use-next-versions-001/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/versions-changes.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<update artifactId=\"dummy-api\" groupId=\"localhost\" kind=\"useNextVersions\" newVersion=\"1.1.2\" oldVersion=\"1.1.1-2\"/>" ) < 0 )
+    {
+        System.err.println( "Version change recorded" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
@@ -42,9 +42,11 @@ import java.util.regex.Pattern;
  * @author Paul Gier
  * @since 1.0-alpha-3
  */
-@Mojo( name = "unlock-snapshots", requiresProject = true, requiresDirectInvocation = true, threadSafe = true )
-public class UnlockSnapshotsMojo
-    extends AbstractVersionsDependencyUpdaterMojo
+@Mojo( name = "unlock-snapshots",
+       requiresProject = true,
+       requiresDirectInvocation = true,
+       threadSafe = true )
+public class UnlockSnapshotsMojo extends AbstractVersionsDependencyUpdaterMojo
 {
 
     // ------------------------------ FIELDS ------------------------------
@@ -59,12 +61,11 @@ public class UnlockSnapshotsMojo
     /**
      * @param pom the pom to update.
      * @throws MojoExecutionException when things go wrong
-     * @throws MojoFailureException when things go wrong in a very bad way
-     * @throws XMLStreamException when things go wrong with XML streaming
+     * @throws MojoFailureException   when things go wrong in a very bad way
+     * @throws XMLStreamException     when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(ModifiedPomXMLEventReader)
      */
-    protected void update( ModifiedPomXMLEventReader pom )
-        throws MojoExecutionException, MojoFailureException, XMLStreamException
+    protected void update( ModifiedPomXMLEventReader pom ) throws MojoExecutionException, MojoFailureException, XMLStreamException
     {
 
         if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
@@ -81,8 +82,7 @@ public class UnlockSnapshotsMojo
         }
     }
 
-    private void unlockSnapshots( ModifiedPomXMLEventReader pom, List<Dependency> dependencies )
-        throws XMLStreamException, MojoExecutionException
+    private void unlockSnapshots( ModifiedPomXMLEventReader pom, List<Dependency> dependencies ) throws XMLStreamException, MojoExecutionException
     {
         for ( Dependency dep : dependencies )
         {
@@ -109,16 +109,17 @@ public class UnlockSnapshotsMojo
             {
                 String unlockedVersion = versionMatcher.replaceFirst( "-SNAPSHOT" );
                 if ( PomHelper.setDependencyVersion( pom, dep.getGroupId(), dep.getArtifactId(), dep.getVersion(),
-                                                     unlockedVersion, getProject().getModel() ) )
+                        unlockedVersion, getProject().getModel() ) )
                 {
+                    this.getChangeRecorder().recordUpdate( "unlockSnapshot", dep.getGroupId(), dep.getArtifactId(),
+                            dep.getVersion(), unlockedVersion );
                     getLog().info( "Unlocked " + toString( dep ) + " to version " + unlockedVersion );
                 }
             }
         }
     }
 
-    private void unlockParentSnapshot( ModifiedPomXMLEventReader pom, MavenProject parent )
-        throws XMLStreamException, MojoExecutionException
+    private void unlockParentSnapshot( ModifiedPomXMLEventReader pom, MavenProject parent ) throws XMLStreamException, MojoExecutionException
     {
         if ( parent == null )
         {
@@ -143,6 +144,8 @@ public class UnlockSnapshotsMojo
             {
                 getLog().info( "Unlocked parent " + parentArtifact + " to version "
                     + unlockedParentVersion );
+                this.getChangeRecorder().recordUpdate( "unlockParentVersion", parentArtifact.getGroupId(),
+                        parentArtifact.getArtifactId(), parentArtifact.getVersion(), unlockedParentVersion );
             }
         }
     }

--- a/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
@@ -39,9 +39,11 @@ import javax.xml.stream.XMLStreamException;
  * @author Stephen Connolly
  * @since 1.0-alpha-1
  */
-@Mojo( name = "update-parent", requiresProject = true, requiresDirectInvocation = true, threadSafe = true )
-public class UpdateParentMojo
-    extends AbstractVersionsUpdaterMojo
+@Mojo( name = "update-parent",
+       requiresProject = true,
+       requiresDirectInvocation = true,
+       threadSafe = true )
+public class UpdateParentMojo extends AbstractVersionsUpdaterMojo
 {
 
     // ------------------------------ FIELDS ------------------------------
@@ -51,7 +53,8 @@ public class UpdateParentMojo
      *
      * @since 1.0-alpha-1
      */
-    @Parameter( property = "parentVersion", defaultValue = "null" )
+    @Parameter( property = "parentVersion",
+                defaultValue = "null" )
     protected String parentVersion = null;
 
     /**
@@ -67,13 +70,12 @@ public class UpdateParentMojo
     /**
      * @param pom the pom to update.
      * @throws MojoExecutionException when things go wrong
-     * @throws MojoFailureException when things go wrong in a very bad way
-     * @throws XMLStreamException when things go wrong with XML streaming
+     * @throws MojoFailureException   when things go wrong in a very bad way
+     * @throws XMLStreamException     when things go wrong with XML streaming
      * @see AbstractVersionsUpdaterMojo#update(ModifiedPomXMLEventReader)
      * @since 1.0-alpha-1
      */
-    protected void update( ModifiedPomXMLEventReader pom )
-        throws MojoExecutionException, MojoFailureException, XMLStreamException
+    protected void update( ModifiedPomXMLEventReader pom ) throws MojoExecutionException, MojoFailureException, XMLStreamException
     {
         if ( getProject().getParent() == null )
         {
@@ -106,8 +108,7 @@ public class UpdateParentMojo
         }
 
         Artifact artifact = artifactFactory.createDependencyArtifact( getProject().getParent().getGroupId(),
-                                                                      getProject().getParent().getArtifactId(),
-                                                                      versionRange, "pom", null, null );
+                getProject().getParent().getArtifactId(), versionRange, "pom", null, null );
 
         ArtifactVersion artifactVersion;
         try
@@ -129,6 +130,9 @@ public class UpdateParentMojo
         if ( PomHelper.setProjectParentVersion( pom, artifactVersion.toString() ) )
         {
             getLog().debug( "Made an update from " + currentVersion + " to " + artifactVersion );
+
+            this.getChangeRecorder().recordUpdate( "updateParent", artifact.getGroupId(), artifact.getArtifactId(),
+                    currentVersion, artifactVersion.toString() );
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -19,10 +19,12 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -143,8 +145,17 @@ public class UpdatePropertyMojo
             }
 
             int segment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates, allowIncrementalUpdates );
-            updatePropertyToNewestVersion( pom, property, version, currentVersion, allowDowngrade, segment );
+            ArtifactVersion targetVersion = updatePropertyToNewestVersion( pom, property, version, currentVersion,
+                    allowDowngrade, segment );
 
+            if (targetVersion != null)
+            {
+                for ( final ArtifactAssociation association : version.getAssociations() )
+                {
+                    this.getChangeRecorder().recordUpdate( "updateProperty", association.getGroupId(),
+                            association.getArtifactId(), currentVersion, targetVersion.toString() );
+                }
+            }
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -34,42 +34,50 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
+import javax.xml.stream.XMLStreamException;
+import java.util.Collection;
+
 /**
  * @author Dan Arcari
  * @since 2.3
  */
-@Mojo( name = "use-dep-version", requiresProject = true, requiresDirectInvocation = true, threadSafe = true )
-public class UseDepVersionMojo
-    extends AbstractVersionsDependencyUpdaterMojo
+@Mojo( name = "use-dep-version",
+       requiresProject = true,
+       requiresDirectInvocation = true,
+       threadSafe = true )
+public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo
 {
 
     /**
      * The exact version to be applied for the included dependencies
      */
-    @Parameter( property = "depVersion", required = true )
+    @Parameter( property = "depVersion",
+                required = true )
     protected String depVersion;
 
     /**
      * If set to true, will use whatever version is supplied without attempting to validate that such a version is
      * obtainable from the repository chain.
      */
-    @Parameter( property = "forceVersion", defaultValue = "false" )
+    @Parameter( property = "forceVersion",
+                defaultValue = "false" )
     protected boolean forceVersion;
 
     @SuppressWarnings( "unchecked" )
     @Override
-    protected void update( ModifiedPomXMLEventReader pom )
-        throws MojoExecutionException, MojoFailureException, XMLStreamException, ArtifactMetadataRetrievalException
+    protected void update( ModifiedPomXMLEventReader pom ) throws MojoExecutionException, MojoFailureException, XMLStreamException, ArtifactMetadataRetrievalException
     {
 
         if ( depVersion == null || depVersion.equals( "" ) )
         {
-            throw new IllegalArgumentException( "depVersion must be supplied with use-specific-version, and cannot be blank." );
+            throw new IllegalArgumentException(
+                    "depVersion must be supplied with use-specific-version, and cannot be blank." );
         }
 
         if ( !forceVersion && !hasIncludes() )
         {
-            throw new IllegalArgumentException( "The use-specific-version goal is intended to be used with a single artifact. Please specify a value for the 'includes' parameter, or use -DforceVersion=true to override this check." );
+            throw new IllegalArgumentException(
+                    "The use-specific-version goal is intended to be used with a single artifact. Please specify a value for the 'includes' parameter, or use -DforceVersion=true to override this check." );
         }
 
         try
@@ -90,8 +98,7 @@ public class UseDepVersionMojo
         }
     }
 
-    private void useDepVersion( ModifiedPomXMLEventReader pom, Collection<Dependency> dependencies )
-        throws MojoExecutionException, XMLStreamException, ArtifactMetadataRetrievalException
+    private void useDepVersion( ModifiedPomXMLEventReader pom, Collection<Dependency> dependencies ) throws MojoExecutionException, XMLStreamException, ArtifactMetadataRetrievalException
     {
         for ( Dependency dep : dependencies )
         {
@@ -117,18 +124,21 @@ public class UseDepVersionMojo
 
                     if ( !versions.containsVersion( depVersion ) )
                     {
-                        throw new MojoExecutionException( String.format( "Version %s is not available for artifact %s:%s",
-                                                                         depVersion, artifact.getGroupId(),
-                                                                         artifact.getArtifactId() ) );
+                        throw new MojoExecutionException(
+                                String.format( "Version %s is not available for artifact %s:%s", depVersion,
+                                        artifact.getGroupId(), artifact.getArtifactId() ) );
                     }
                 }
 
                 String version = dep.getVersion();
 
                 if ( PomHelper.setDependencyVersion( pom, dep.getGroupId(), dep.getArtifactId(), version, depVersion,
-                                                     getProject().getModel() ) )
+                        getProject().getModel() ) )
                 {
                     getLog().info( "Updated " + toString( dep ) + " to version " + depVersion );
+
+                    this.getChangeRecorder().recordUpdate( "useDependencyVersion", dep.getGroupId(),
+                            dep.getArtifactId(), version, depVersion );
                 }
             }
         }

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -182,6 +182,9 @@ public class UseLatestReleasesMojo
                                                          newVersion, getProject().getModel() ) )
                     {
                         getLog().info( "Updated " + toString( dep ) + " to version " + newVersion );
+
+                        this.getChangeRecorder().recordUpdate( "useLatestReleases", dep.getGroupId(),
+                                dep.getArtifactId(), version, newVersion );
                     }
                 }
             }

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -63,7 +63,7 @@ public class UseLatestSnapshotsMojo
 
     /**
      * Whether to allow the minor version number to be changed.
-     * 
+     *
      * @since 1.0-beta-1
      */
     @Parameter( property = "allowMinorUpdates", defaultValue = "false" )
@@ -196,11 +196,15 @@ public class UseLatestSnapshotsMojo
                     latestVersion = filteredVersions[filteredVersions.length - 1].toString();
                     if ( getProject().getParent() != null )
                     {
-                        if ( artifact.getId().equals(getProject().getParentArtifact().getId()) && isProcessingParent() )
+                        final Artifact parentArtifact = getProject().getParentArtifact();
+                        if ( artifact.getId().equals( parentArtifact.getId()) && isProcessingParent() )
                         {
                             if ( PomHelper.setProjectParentVersion( pom, latestVersion ) )
                             {
                                 getLog().debug( "Made parent update from " + version + " to " + latestVersion );
+
+                                this.getChangeRecorder().recordUpdate( "useLatestSnapshots", parentArtifact.getGroupId(),
+                                        parentArtifact.getArtifactId(), version, latestVersion );
                             }
                         }
                     }
@@ -209,6 +213,9 @@ public class UseLatestSnapshotsMojo
                                                          latestVersion, getProject().getModel() ) )
                     {
                         getLog().info( "Updated " + toString( dep ) + " to version " + latestVersion );
+
+                        this.getChangeRecorder().recordUpdate( "useLatestSnapshots", dep.getGroupId(),
+                                dep.getArtifactId(), version, latestVersion );
                     }
                 }
             }

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -163,10 +163,14 @@ public class UseLatestVersionsMojo
                 String newVersion = filteredVersions[filteredVersions.length - 1].toString();
                 if ( getProject().getParent() != null )
                 {
-                    if ( artifact.getId().equals( getProject().getParentArtifact().getId() ) && isProcessingParent() )
+                    final Artifact parentArtifact = getProject().getParentArtifact();
+                    if ( artifact.getId().equals( parentArtifact.getId() ) && isProcessingParent() )
                     {
                         if ( PomHelper.setProjectParentVersion( pom, newVersion ) ) {
                             getLog().debug("Made parent update from " + version + " to " + newVersion);
+
+                            this.getChangeRecorder().recordUpdate( "useLatestVersions", parentArtifact.getGroupId(),
+                                    parentArtifact.getArtifactId(), version, newVersion );
                         }
                     }
                 }
@@ -174,6 +178,8 @@ public class UseLatestVersionsMojo
                                                      getProject().getModel() ) ) {
                     getLog().info( "Updated " + toString( dep ) + " to version " + newVersion );
 
+                    this.getChangeRecorder().recordUpdate( "useLatestVersions", dep.getGroupId(),
+                            dep.getArtifactId(), version, newVersion );
                 }
             }
 

--- a/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -113,6 +113,9 @@ public class UseNextReleasesMojo
 
                     {
                         getLog().info( "Updated " + toString( dep ) + " to version " + newVersion );
+
+                        this.getChangeRecorder().recordUpdate( "useNextReleases", dep.getGroupId(),
+                                dep.getArtifactId(), version, newVersion );
                     }
                 }
             }

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -162,6 +162,9 @@ public class UseNextSnapshotsMojo
                                                              newVersion, getProject().getModel() ) )
                         {
                             getLog().info( "Updated " + toString( dep ) + " to version " + newVersion );
+
+                            this.getChangeRecorder().recordUpdate( "useNextSnapshots", dep.getGroupId(),
+                                    dep.getArtifactId(), version, newVersion );
                         }
                         break;
                     }

--- a/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
@@ -106,6 +106,9 @@ public class UseNextVersionsMojo
                                                      getProject().getModel() ) )
                 {
                     getLog().info( "Updated " + toString( dep ) + " to version " + newVersion );
+
+                    this.getChangeRecorder().recordUpdate( "useNextVersions", dep.getGroupId(),
+                            dep.getArtifactId(), version, newVersion );
                 }
             }
         }

--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -129,8 +129,9 @@ public class UseReleasesMojo
                 throw new MojoExecutionException( "Invalid version range specification: " + version, e );
             }
 
-            Artifact artifact = artifactFactory.createDependencyArtifact( getProject().getParent().getGroupId(),
-                                                                          getProject().getParent().getArtifactId(),
+            final MavenProject parent = getProject().getParent();
+            Artifact artifact = artifactFactory.createDependencyArtifact( parent.getGroupId(),
+                                                                          parent.getArtifactId(),
                                                                           versionRange, "pom", null, null );
             if ( !isIncluded( artifact ) )
             {
@@ -175,6 +176,9 @@ public class UseReleasesMojo
                     if ( PomHelper.setProjectParentVersion( pom, finalVersion.toString() ) )
                     {
                         getLog().info( "Updated " + toString( project ) + " to version " + finalVersion );
+
+                        this.getChangeRecorder().recordUpdate( "useReleases", parent.getGroupId(),
+                                parent.getArtifactId(), version, finalVersion.toString() );
                     }
                 }
                 else
@@ -237,8 +241,7 @@ public class UseReleasesMojo
     }
 
     private void rangeMatching( ModifiedPomXMLEventReader pom, Dependency dep, String version, String releaseVersion,
-                                ArtifactVersions versions )
-        throws XMLStreamException
+                                ArtifactVersions versions ) throws XMLStreamException, MojoExecutionException
     {
         ArtifactVersion finalVersion = null;
         for ( ArtifactVersion proposedVersion : versions.getVersions( false ) )
@@ -256,6 +259,9 @@ public class UseReleasesMojo
                                                  finalVersion.toString(), getProject().getModel() ) )
             {
                 getLog().info( "Updated " + toString( dep ) + " to version " + finalVersion );
+
+                this.getChangeRecorder().recordUpdate( "useReleases", dep.getGroupId(),
+                        dep.getArtifactId(), version, finalVersion.toString() );
             }
         }
         else
@@ -270,8 +276,7 @@ public class UseReleasesMojo
     }
 
     private void noRangeMatching( ModifiedPomXMLEventReader pom, Dependency dep, String version, String releaseVersion,
-                                  ArtifactVersions versions )
-        throws XMLStreamException
+                                  ArtifactVersions versions ) throws XMLStreamException, MojoExecutionException
     {
         if ( versions.containsVersion( releaseVersion ) )
         {
@@ -279,6 +284,9 @@ public class UseReleasesMojo
                                                  getProject().getModel() ) )
             {
                 getLog().info( "Updated " + toString( dep ) + " to version " + releaseVersion );
+
+                this.getChangeRecorder().recordUpdate( "useReleases", dep.getGroupId(),
+                        dep.getArtifactId(), version, releaseVersion );
             }
         }
         else if ( failIfNotReplaced )

--- a/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorder.java
+++ b/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorder.java
@@ -1,0 +1,51 @@
+package org.codehaus.mojo.versions.recording;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A recorder of version updates.
+ */
+
+public interface ChangeRecorder
+{
+    /**
+     * Record that a dependency was updated.
+     *
+     * @param kind       The kind of version change
+     * @param groupId    The dependency group ID
+     * @param artifactId The dependency artifact ID
+     * @param oldVersion The old version of the dependency
+     * @param newVersion The new version of the dependency
+     */
+
+    void recordUpdate( String kind, String groupId, String artifactId, String oldVersion, String newVersion );
+
+    /**
+     * Serialize the current set of changes to the given output stream.
+     *
+     * @param outputStream The output stream
+     * @throws IOException On serialization and/or I/O errors
+     */
+
+    void serialize( OutputStream outputStream ) throws IOException;
+}

--- a/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorderNull.java
+++ b/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorderNull.java
@@ -1,0 +1,63 @@
+package org.codehaus.mojo.versions.recording;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+/**
+ * A recorder that ignores updates.
+ */
+
+public class ChangeRecorderNull implements ChangeRecorder
+{
+    /**
+     * Create a new change recorder that serializes to XML.
+     *
+     * @return A new change recorder
+     */
+
+    public static ChangeRecorder create()
+    {
+        return new ChangeRecorderNull();
+    }
+
+    private ChangeRecorderNull()
+    {
+
+    }
+
+    @Override
+    public final void recordUpdate( final String kind, final String groupId, final String artifactId, final String oldVersion, final String newVersion )
+    {
+        Objects.requireNonNull( kind, "kind" );
+        Objects.requireNonNull( groupId, "groupId" );
+        Objects.requireNonNull( artifactId, "artifactId" );
+        Objects.requireNonNull( oldVersion, "oldVersion" );
+        Objects.requireNonNull( newVersion, "newVersion" );
+    }
+
+    @Override
+    public final void serialize( final OutputStream outputStream ) throws IOException
+    {
+
+    }
+}

--- a/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorderXML.java
+++ b/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorderXML.java
@@ -1,0 +1,116 @@
+package org.codehaus.mojo.versions.recording;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+/**
+ * A recorder of version updates.
+ */
+
+public class ChangeRecorderXML implements ChangeRecorder
+{
+    /**
+     * The XML namespace used for serialized changes.
+     */
+
+    public static final String CHANGES_NAMESPACE = "http://www.mojohaus.org/versions-maven-plugin/schema/updates/1.0";
+
+    private final Document document;
+    private final Element root;
+
+    /**
+     * Create a new change recorder that serializes to XML.
+     *
+     * @return A new change recorder
+     */
+
+    public static ChangeRecorder create()
+    {
+        try
+        {
+            final DocumentBuilderFactory documentBuilders = DocumentBuilderFactory.newInstance();
+            final DocumentBuilder documentBuilder = documentBuilders.newDocumentBuilder();
+            final Document document = documentBuilder.newDocument();
+            final Element root = document.createElementNS( CHANGES_NAMESPACE, "updates" );
+            document.appendChild( root );
+            return new ChangeRecorderXML( document, root );
+        }
+        catch ( final ParserConfigurationException | DOMException e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+
+    private ChangeRecorderXML( final Document document, final Element root )
+    {
+        this.document = Objects.requireNonNull( document, "document" );
+        this.root = Objects.requireNonNull( root, "root" );
+    }
+
+    @Override
+    public final void recordUpdate( final String kind, final String groupId, final String artifactId, final String oldVersion, final String newVersion )
+    {
+        Objects.requireNonNull( kind, "kind" );
+        Objects.requireNonNull( groupId, "groupId" );
+        Objects.requireNonNull( artifactId, "artifactId" );
+        Objects.requireNonNull( oldVersion, "oldVersion" );
+        Objects.requireNonNull( newVersion, "newVersion" );
+
+        final Element update = this.document.createElementNS( CHANGES_NAMESPACE, "update" );
+        update.setAttribute( "kind", kind );
+        update.setAttribute( "groupId", groupId );
+        update.setAttribute( "artifactId", artifactId );
+        update.setAttribute( "oldVersion", oldVersion );
+        update.setAttribute( "newVersion", newVersion );
+        this.root.appendChild( update );
+    }
+
+    @Override
+    public final void serialize( final OutputStream outputStream ) throws IOException
+    {
+        try
+        {
+            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            final Source source = new DOMSource( this.document );
+            transformer.transform( source, new StreamResult( outputStream ) );
+            outputStream.flush();
+        }
+        catch ( final TransformerException ex )
+        {
+            throw new IOException( ex );
+        }
+    }
+}

--- a/src/main/resources/org/codehaus/mojo/versions/recording/schema-1.0.xsd
+++ b/src/main/resources/org/codehaus/mojo/versions/recording/schema-1.0.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified"
+        xmlns:u="http://www.mojohaus.org/versions-maven-plugin/schema/updates/1.0"
+        targetNamespace="http://www.mojohaus.org/versions-maven-plugin/schema/updates/1.0">
+
+    <annotation>
+        <documentation>
+            The 'update' element specifies a single version change. The 'kind' attribute describes the
+            operation that produced the version update, such as unlocking a snapshot version or upgrading to the next
+            release.
+        </documentation>
+    </annotation>
+
+    <element name="update">
+        <complexType>
+            <attribute name="kind" type="NMTOKEN" use="required"/>
+            <attribute name="groupId" type="NMTOKEN" use="required"/>
+            <attribute name="artifactId" type="NMTOKEN" use="required"/>
+            <attribute name="oldVersion" type="NMTOKEN" use="required"/>
+            <attribute name="newVersion" type="NMTOKEN" use="required"/>
+        </complexType>
+    </element>
+
+    <annotation>
+        <documentation>The 'updates' element specifies a set of version changes that occurred.</documentation>
+    </annotation>
+
+    <element name="updates">
+        <complexType>
+            <sequence minOccurs="0" maxOccurs="unbounded">
+                <element ref="u:update"/>
+            </sequence>
+        </complexType>
+    </element>
+
+</schema>

--- a/src/site/apt/examples/recording-changes.apt
+++ b/src/site/apt/examples/recording-changes.apt
@@ -1,0 +1,49 @@
+ ~~ Licensed to the Apache Software Foundation (ASF) under one
+ ~~ or more contributor license agreements.  See the NOTICE file
+ ~~ distributed with this work for additional information
+ ~~ regarding copyright ownership.  The ASF licenses this file
+ ~~ to you under the Apache License, Version 2.0 (the
+ ~~ "License"); you may not use this file except in compliance
+ ~~ with the License.  You may obtain a copy of the License at
+ ~~
+ ~~   http://www.apache.org/licenses/LICENSE-2.0
+ ~~
+ ~~ Unless required by applicable law or agreed to in writing,
+ ~~ software distributed under the License is distributed on an
+ ~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~~ KIND, either express or implied.  See the License for the
+ ~~ specific language governing permissions and limitations
+ ~~ under the License.
+
+ -----
+ Recording Changes
+ -----
+ Mark Raynsford
+ ------
+ 2020-06-27
+ ------
+
+Recording Changes
+
+  Here's an example:
+
+---
+mvn versions:use-latest-releases -DchangeRecorderFormat=xml
+---
+
+  Which writes a file to <<<target/versions-changes.xml>>> that looks something
+  like:
+
+---
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<updates xmlns="http://www.mojohaus.org/versions-maven-plugin/schema/updates/1.0">
+  <update artifactId="dummy-api"
+          groupId="localhost"
+          kind="useLatestReleases"
+          newVersion="3.0"
+          oldVersion="1.1.1-2"/>
+</updates>
+---
+
+  The contents of this file records the fact that <<<localhost:dummy-api:1.1.1-2>>>
+  was upgraded to <<<3.0>>>.

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -164,3 +164,6 @@ Versions Maven Plugin
   * {{{./examples/use-releases.html}Replacing -SNAPSHOT versions with their corresponding releases}}
 
   * {{{./examples/set.html}Changing the project version}}
+
+  * {{{./examples/recording-changes.html}Recording version changes}}
+

--- a/src/test/java/org/codehaus/mojo/versions/recording/ChangeRecorderXMLTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/recording/ChangeRecorderXMLTest.java
@@ -1,0 +1,98 @@
+package org.codehaus.mojo.versions.recording;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class ChangeRecorderXMLTest
+{
+    private static void copyResource( final String name, final File output ) throws IOException
+    {
+        try ( FileOutputStream outputStream = new FileOutputStream( output ) )
+        {
+            try ( InputStream inputStream = ChangeRecorderXMLTest.class.getResourceAsStream( name ) )
+            {
+                IOUtils.copy( inputStream, outputStream );
+            }
+        }
+    }
+
+    private static Document parseXML( final File file ) throws ParserConfigurationException, IOException, SAXException
+    {
+        final DocumentBuilderFactory documentBuilders = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder documentBuilder = documentBuilders.newDocumentBuilder();
+        return documentBuilder.parse( file );
+    }
+
+    @Test
+    public void testChanges() throws Exception
+    {
+        final File file0 = File.createTempFile( "ChangeRecorderTest", ".xml" );
+        final File file1 = File.createTempFile( "ChangeRecorderTest", ".xml" );
+
+        copyResource( "expectedFile.xml", file0 );
+
+        final ChangeRecorder recorder = ChangeRecorderXML.create();
+        recorder.recordUpdate( "exampleKind", "org.codehaus", "example0", "0.0.1", "0.0.2" );
+        recorder.recordUpdate( "exampleKind", "org.codehaus", "example1", "1.0.0", "2.0.0" );
+
+        try ( FileOutputStream outputStream = new FileOutputStream( file1 ) )
+        {
+            recorder.serialize( outputStream );
+        }
+
+        final Document document0 = parseXML( file0 );
+        final Document document1 = parseXML( file1 );
+
+        final NodeList elements0 = document0.getElementsByTagNameNS( ChangeRecorderXML.CHANGES_NAMESPACE, "updated" );
+        final NodeList elements1 = document1.getElementsByTagNameNS( ChangeRecorderXML.CHANGES_NAMESPACE, "updated" );
+
+        Assert.assertEquals( "Correct number of updates", elements0.getLength(), elements1.getLength() );
+
+        for ( int index = 0; index < elements0.getLength(); ++index )
+        {
+            final Element element0 = (Element) elements0.item( index );
+            final Element element1 = (Element) elements1.item( index );
+
+            Assert.assertEquals( element0.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "artifactId" ),
+                    element1.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "artifactId" ) );
+            Assert.assertEquals( element0.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "groupId" ),
+                    element1.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "groupId" ) );
+            Assert.assertEquals( element0.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "oldVersion" ),
+                    element1.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "oldVersion" ) );
+            Assert.assertEquals( element0.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "newVersion" ),
+                    element1.getAttributeNS( ChangeRecorderXML.CHANGES_NAMESPACE, "newVersion" ) );
+        }
+    }
+}

--- a/src/test/resources/org/codehaus/mojo/versions/recording/expectedFile.xml
+++ b/src/test/resources/org/codehaus/mojo/versions/recording/expectedFile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<u:updates xmlns:u="http://www.mojohaus.org/versions-maven-plugin/schema/updates/1.0">
+    <u:update u:groupId="org.mojohaus" u:artifactId="example0" u:oldVersion="0.0.1" u:newVersion="0.0.2"/>
+    <u:update u:groupId="org.mojohaus" u:artifactId="example1" u:oldVersion="1.0.0" u:newVersion="2.0.0"/>
+</u:updates>


### PR DESCRIPTION
This provides a ChangeRecorder interface that logs changes to a machine-readable XML file whenever a pom.xml file is updated. The XML format is fully specified with an XSD schema. By default, no logging of changes occurs. 

Change recording can be enabled by specifying the `changeRecorderFormat` and `changeRecorderOutputFile` properties (the latter of which logs to a `versions-changes.xml` file in the output directory by default). If `changeRecorderFormat = none` (the default), no logging occurs. If `changeRecorderFormat = xml`, the changes will be logged in the XML format.

Ticket: https://github.com/mojohaus/versions-maven-plugin/issues/356