### PR TITLE
Fixes #426 restore default behavior on setting versions in all modules of the local aggregation root that was present before the fix for #82

### DIFF
--- a/src/it/it-set-018-issue-82/invoker.properties
+++ b/src/it/it-set-018-issue-82/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -fmodule-a1 -DnewVersion=2.5.0-SNAPSHOT
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -fmodule-a1 -DnewVersion=2.5.0-SNAPSHOT -DprocessFromLocalAggregationRoot=false
 invoker.nonRecursive=true
 invoker.buildResult=success

--- a/src/it/it-set-019-issue-426/invoker.properties
+++ b/src/it/it-set-019-issue-426/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -fmodule-a1 -DnewVersion=2.5.0-SNAPSHOT
+invoker.nonRecursive=true
+invoker.buildResult=success

--- a/src/it/it-set-019-issue-426/module-a1/module-b1/pom.xml
+++ b/src/it/it-set-019-issue-426/module-a1/module-b1/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>module-a1</artifactId>
+    <version>2.0.7-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-b1</artifactId>
+  <packaging>pom</packaging>
+</project>

--- a/src/it/it-set-019-issue-426/module-a1/module-b2/pom.xml
+++ b/src/it/it-set-019-issue-426/module-a1/module-b2/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>module-a1</artifactId>
+    <version>2.0.7-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-b2</artifactId>
+  <version>2.0.7-SNAPSHOT</version>
+  <packaging>pom</packaging>
+</project>

--- a/src/it/it-set-019-issue-426/module-a1/module-b3/pom.xml
+++ b/src/it/it-set-019-issue-426/module-a1/module-b3/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localdomain.localhost</groupId>
+    <artifactId>module-a1</artifactId>
+    <version>2.0.7-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-b3</artifactId>
+  <version>2.0.7-SNAPSHOT</version>
+  <packaging>pom</packaging>
+</project>

--- a/src/it/it-set-019-issue-426/module-a1/pom.xml
+++ b/src/it/it-set-019-issue-426/module-a1/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a1</artifactId>
+  <packaging>pom</packaging>
+  <version>2.0.7-SNAPSHOT</version>
+  <modules>
+    <module>module-b1</module>
+    <module>module-b2</module>
+    <module>module-b3</module>
+  </modules>
+</project>

--- a/src/it/it-set-019-issue-426/module-a2/pom.xml
+++ b/src/it/it-set-019-issue-426/module-a2/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>module-a2</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0.3-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>localdomain.localhost</groupId>
+      <artifactId>module-b1</artifactId>
+      <version>2.0.7-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/it-set-019-issue-426/pom.xml
+++ b/src/it/it-set-019-issue-426/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>project-a</artifactId>
+  <packaging>pom</packaging>
+  <version>1.2.0-SNAPSHOT</version>
+  <name>mversions-82</name>
+
+  <description>
+    invoking versions:set on child pom - make sure all child poms are affected
+  </description>
+  
+  <modules>
+    <module>module-a1</module>
+    <module>module-a2</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.2-beta-2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ear-plugin</artifactId>
+          <version>2.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-ejb-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-rar-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.0-beta-7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.0.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.1-alpha-1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/it-set-019-issue-426/verify.groovy
+++ b/src/it/it-set-019-issue-426/verify.groovy
@@ -1,0 +1,67 @@
+import org.apache.commons.lang.StringUtils
+
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPathFactory
+
+class Checker
+{
+  def result = true;
+
+  def basedir;
+
+  public Checker(File basedir) {
+    this.basedir = basedir;
+  }
+
+  def readXPath( String pom, String xPathExpression )
+  {
+    def stream = new FileInputStream( new File( basedir, pom ) );
+    try
+    {
+      return XPathFactory.newInstance()
+              .newXPath()
+              .evaluate( xPathExpression, DocumentBuilderFactory.newInstance()
+              .newDocumentBuilder()
+              .parse( stream ).documentElement );
+    }
+    finally
+    {
+      stream.close();
+    }
+  }
+
+  Checker check( String message, String pom, String xpath, String expected )
+  {
+    if ( result )
+    {
+      try
+      {
+        def actual = readXPath( pom, xpath )
+        if ( !StringUtils.equals( expected, actual ) )
+        {
+          System.out.println( pom + " [xpath:" + xpath + "] expected '" + expected + "' found '" + actual + "' : " + message );
+          result = false;
+        }
+      }
+      catch ( Throwable t )
+      {
+        t.printStackTrace();
+        result = false;
+      }
+    }
+    return this;
+  }
+}
+
+return new Checker(basedir)
+        .check( "root pom unchanged", "pom.xml", "/project/version", "1.2.0-SNAPSHOT" )
+        .check( "module-a1 changed", "module-a1/pom.xml", "/project/version", "2.5.0-SNAPSHOT" )
+        .check( "module-a1/module-b1 parent changed", "module-a1/module-b1/pom.xml", "/project/parent/version", "2.5.0-SNAPSHOT" )
+        .check( "module-a1/module-b1 remains unspecified", "module-a1/module-b1/pom.xml", "/project/version", "" )
+        .check( "module-a1/module-b2 parent changed", "module-a1/module-b2/pom.xml", "/project/parent/version", "2.5.0-SNAPSHOT" )
+        .check( "module-a1/module-b2 version changed", "module-a1/module-b2/pom.xml", "/project/version", "2.5.0-SNAPSHOT" )
+        .check( "module-a1/module-b3 parent changed", "module-a1/module-b3/pom.xml", "/project/parent/version", "2.5.0-SNAPSHOT" )
+        .check( "module-a1/module-b3 version changed", "module-a1/module-b3/pom.xml", "/project/version", "2.5.0-SNAPSHOT" )
+        .check( "module-a2 unchanged", "module-a2/pom.xml", "/project/version", "1.0.3-SNAPSHOT" )
+        .check( "module-a2 dependency changed", "module-a2/pom.xml", "/project/dependencies/dependency/version", "2.5.0-SNAPSHOT" )
+        .result;

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -189,6 +189,16 @@ public class SetMojo
     private boolean processAllModules;
 
     /**
+     * Whether to start processing at the local aggregation root (which might be a parent module
+     * of that module where Maven is executed in, and the version change may affect parent and sibling modules).
+     * Setting to fale makes sure only the module (and it's submodule) where Maven is executed for is affected.
+     *
+     * @since 2.9
+     */
+    @Parameter( property = "processFromLocalAggregationRoot", defaultValue = "true" )
+    private boolean processFromLocalAggregationRoot;
+
+    /**
      * The changes to module coordinates. Guarded by this.
      */
     private final transient List<VersionChange> sourceChanges = new ArrayList<>();
@@ -281,7 +291,13 @@ public class SetMojo
 
         try
         {
-            final MavenProject project = getProject();
+            final MavenProject project;
+            if ( processFromLocalAggregationRoot ) {
+                project = PomHelper.getLocalRoot( projectBuilder, getProject(), localRepository, null, getLog() );
+            }
+            else {
+                project = getProject();
+            }
 
             getLog().info( "Local aggregation root: " + project.getBasedir() );
             Map<String, Model> reactorModels = PomHelper.getReactorModels( project, getLog() );

--- a/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -1377,6 +1377,55 @@ public class PomHelper
     }
 
     /**
+     * Finds the local root of the specified project.
+     *
+     * @param project The project to find the local root for.
+     * @param localRepository the local repo.
+     * @param globalProfileManager the global profile manager.
+     * @param logger The logger to log to.
+     * @return The local root (note this may be the project passed as an argument).
+     */
+    public static MavenProject getLocalRoot( MavenProjectBuilder builder, MavenProject project,
+                                             ArtifactRepository localRepository, ProfileManager globalProfileManager,
+                                             Log logger )
+    {
+        logger.info( "Searching for local aggregator root..." );
+        while ( true )
+        {
+            final File parentDir = project.getBasedir().getParentFile();
+            if ( parentDir != null && parentDir.isDirectory() )
+            {
+                logger.debug( "Checking to see if " + parentDir + " is an aggregator parent" );
+                File parent = new File( parentDir, "pom.xml" );
+                if ( parent.isFile() )
+                {
+                    try
+                    {
+                        final MavenProject parentProject =
+                            builder.build( parent, localRepository, globalProfileManager );
+                        if ( getAllChildModules( parentProject, logger ).contains( project.getBasedir().getName() ) )
+                        {
+                            logger.debug( parentDir + " is an aggregator parent" );
+                            project = parentProject;
+                            continue;
+                        }
+                        else
+                        {
+                            logger.debug( parentDir + " is not an aggregator parent" );
+                        }
+                    }
+                    catch ( ProjectBuildingException e )
+                    {
+                        logger.warn( e );
+                    }
+                }
+            }
+            logger.debug( "Local aggregation root is " + project.getBasedir() );
+            return project;
+        }
+    }
+
+    /**
      * Builds a map of raw models keyed by module path.
      *
      * @param project The project to build from.


### PR DESCRIPTION
introduce a new flag processFromLocalAggregationRoot that enables the new (and probably more correct) behavior by setting it it false
ensure old and new behavior are covered by integration tests

Fixes #426