### PR TITLE
Sort properties by Property name in "Property Updates Report"

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -870,7 +870,7 @@ public class DefaultVersionsHelper
                                                                     boolean autoLinkItems )
         throws MojoExecutionException
     {
-        Map<String, Property> properties = new HashMap<String, Property>();
+        Map<String, Property> properties = new TreeMap<String, Property>();
         if ( propertyDefinitions != null )
         {
             for ( Property propertyDefinition : propertyDefinitions )


### PR DESCRIPTION
"Plugin Updates Report" and "Dependency Updates Report" are both already sorted by alphabetical order. while "Property Updates Report" was sorted by hash keys. Sorting this report by Property name is just a matter of consistency and readability.