### PR TITLE
Update maven-invoker-plugin to 3.2.2 to fix JDK16 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
         <configuration>
           <projectsDirectory>src/it</projectsDirectory>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>


### PR DESCRIPTION
Fixes these problems in the JDK16 build:
```
[INFO] run post-build script verify.bsh
[INFO]   The post-build script did not succeed. Sourced file: inline evaluation of: ``import java.io.*; import java.util.regex.*;  try {     File file = new File( bas . . . '' unknown error: Unable to make public java.lang.AbstractStringBuilder java.lang.AbstractStringBuilder.append(java.lang.String) accessible: module java.base does not "opens java.lang" to unnamed module @430c04a6
[INFO]           it-update-child-modules-002/pom.xml .............. FAILED (6.3 s)
```
This should be merged ASAP since all more or less recent PRs are affected by this problem (and `master` of course). /cc @sparsick @mfriedenhagen

I guess sooner or later dependabot would have created a PR for this update, but given the importance I thought better do it now.