### PR TITLE
fix(resolve-ranges): fail properly on managed dep without version

### DIFF
--- a/src/it/it-resolve-ranges-issue-442/invoker.properties
+++ b/src/it/it-resolve-ranges-issue-442/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=-X ${project.groupId}:${project.artifactId}:${project.version}:resolve-ranges
+invoker.buildResult=failure

--- a/src/it/it-resolve-ranges-issue-442/pom.xml
+++ b/src/it/it-resolve-ranges-issue-442/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-resolve-ranges-issues-442</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>resolve-ranges IT issue 442</name>
+
+  <description>Test that resolve-range chokes (correctly) on missing version in dependencyManagement</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/src/it/it-resolve-ranges-issue-442/verify.groovy
+++ b/src/it/it-resolve-ranges-issue-442/verify.groovy
@@ -1,0 +1,2 @@
+def buildLogFile = new File(basedir, "build.log")
+assert buildLogFile.text.contains("MojoExecutionException: Found invalid managed dependency junit:junit:jar without a version")

--- a/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import javax.xml.stream.XMLStreamException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -212,6 +213,11 @@ public class ResolveRangesMojo
             if ( isExcludeReactor() && isProducedByReactor( dep ) )
             {
                 continue;
+            }
+
+            if ( StringUtils.isBlank( dep.getVersion() ) )
+            {
+                throw new MojoExecutionException( "Found invalid managed dependency " + toString( dep ) + " without a version");
             }
 
             if ( isHandledByProperty( dep ) )


### PR DESCRIPTION
* `mvn validate` does choke on dependencies without versions.
 * However in managed dependencies a missing version is ignored.
 * resolve-ranges does throw a NPE, which is not helpful.
 * So fail with available coordinates to make fixing easier.
 * When the artifactId is missing in a managed dependency Maven core
will aready fail.

Resolve #442