### PR TITLE
Fixes #469 Support.property file in set-property

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ create/add/fix several issues in one, cause otherwise the history is hard to
 read and to understand and makes the maintenance of the issues and pull request
 hard or to be honest impossible.
 
-Furthermore it is necessary to create appropriate entries into the `ReleaseNotes.md`
-file as well.
-
 
 ## Releasing
 

--- a/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -26,8 +27,11 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+import org.codehaus.mojo.versions.utils.PropertiesVersionsFileReader;
 
 import javax.xml.stream.XMLStreamException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -35,7 +39,7 @@ import java.util.Map;
  * not build anymore. The sanity checks are done by other goals like <code>update-properties</code> or
  * <code>update-property</code> etc. they are not done here. So use this goal with care.
  *
- * @author Karl Heinz Marbaise
+ * @author Karl Heinz Marbaise          
  * @since 2.5
  */
 @Mojo( name = "set-property", requiresProject = true, requiresDirectInvocation = true, threadSafe = true )
@@ -64,6 +68,15 @@ public class SetPropertyMojo
     private boolean autoLinkItems;
 
     /**
+     * A property file name containing: property=value, to update several properties at the same time.
+     * If 'property' and 'newVersion' are also used, they will be ignored.
+     * @since 2.9
+     */
+
+    @Parameter( property = "propertiesVersionsFile" )
+    private String propertiesVersionsFile;
+
+    /**
      * @param pom the pom to update.
      * @throws MojoExecutionException when things go wrong
      * @throws MojoFailureException when things go wrong in a very bad way
@@ -73,24 +86,57 @@ public class SetPropertyMojo
     protected void update( ModifiedPomXMLEventReader pom )
         throws MojoExecutionException, MojoFailureException, XMLStreamException
     {
-        Property propertyConfig = new Property( property );
-        propertyConfig.setVersion( newVersion );
+        Property[] propertiesConfig = null;
+        String properties = "";
+        if (!StringUtils.isEmpty(propertiesVersionsFile) ) {
+            logWrongConfigWarning();
+            getLog().debug( "Reading properties and versions to update from file: " + propertiesVersionsFile );
+            PropertiesVersionsFileReader reader = new PropertiesVersionsFileReader(propertiesVersionsFile);
+            try {
+                reader.read();
+            } catch (IOException e) {
+                getLog().error("Unable to read property file  " + propertiesVersionsFile
+                        + ". re-run with -X option for more details.");
+                getLog().debug("Error while reading  property file " + propertiesVersionsFile, e);
+                throw new MojoFailureException("Unable to read property file " + propertiesVersionsFile);
+            }
+            propertiesConfig = reader.getPropertiesConfig();
+            properties = reader.getProperties();
+        } else {
+            getLog().debug( "Reading properties and versions to update from property and newVersion " );
+            Property propertyConfig = new Property(property);
+            propertyConfig.setVersion(newVersion);
+            propertiesConfig = new Property[] { propertyConfig };
+            properties = property;
+        }
+        update(pom, propertiesConfig, properties);
+    }
+
+    private void update(ModifiedPomXMLEventReader pom, Property[] propertiesConfig, String properties) throws MojoExecutionException, XMLStreamException {
         Map<Property, PropertyVersions> propertyVersions =
-            this.getHelper().getVersionPropertiesMap( getProject(), new Property[] { propertyConfig }, property, "",
+            this.getHelper().getVersionPropertiesMap( getProject(), propertiesConfig, properties, "",
                                                       autoLinkItems );
         for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
         {
-            Property property = entry.getKey();
+            Property currentProperty = entry.getKey();
             PropertyVersions version = entry.getValue();
+            String newVersionGiven = currentProperty.getVersion();
 
-            final String currentVersion = getProject().getProperties().getProperty( property.getName() );
+            final String currentVersion = getProject().getProperties().getProperty( currentProperty.getName() );
             if ( currentVersion == null )
             {
                 continue;
             }
+            PomHelper.setPropertyVersion(pom, version.getProfileId(), currentProperty.getName(), newVersionGiven );
+        }
+    }
 
-            PomHelper.setPropertyVersion( pom, version.getProfileId(), property.getName(), newVersion );
-
+    private void logWrongConfigWarning() {
+        if (!StringUtils.isEmpty(property)) {
+            getLog().warn("-Dproperty provided but will be ignored as -DpropertiesVersionsFile is used");
+        }
+        if (!StringUtils.isEmpty(property)) {
+            getLog().warn("-DnewVersion provided but will be ignored as -DpropertiesVersionsFile is used");
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReader.java
+++ b/src/main/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReader.java
@@ -1,0 +1,59 @@
+package org.codehaus.mojo.versions.utils;
+
+import org.codehaus.mojo.versions.Property;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class PropertiesVersionsFileReader {
+
+    /**
+     * Commas-separated list of properties
+     */
+    private String propertiesCsv;
+
+    private Property[] propertiesConfig;
+
+    private String propertyFilePath;
+
+    public PropertiesVersionsFileReader(String filePath) {
+        propertyFilePath = filePath;
+    }
+
+    public void read() throws IOException {
+        try (InputStream input = new FileInputStream(propertyFilePath)) {
+
+            Properties prop = new Properties();
+
+            // load a properties file
+            prop.load(input);
+
+            prop.propertyNames();
+
+            propertiesCsv = prop.keySet().stream().map(Object::toString).collect(Collectors.joining(","));
+
+            List<Property> propertiesConfigList = new ArrayList<>();
+            prop.forEach((name, version) ->  {
+                Property propertyConfig = new Property((String)name);
+                propertyConfig.setVersion((String)version);
+                propertiesConfigList.add(propertyConfig);
+            });
+
+            propertiesConfig = propertiesConfigList.toArray(new Property[0]);
+        }
+    }
+
+    public String getProperties() {
+        return propertiesCsv;
+    }
+
+    public Property[] getPropertiesConfig() {
+        return propertiesConfig;
+    }
+}

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -72,6 +72,8 @@ Versions Maven Plugin
 
   * {{{./set-mojo.html}versions:set}} can be used to set the project version from the command line.
 
+  * {{{./set-property-mojo.html}versions:set-property}} can be used to set one or multiple properties to a given version from the command line.
+
   * {{{./use-releases-mojo.html}versions:use-releases}} searches the pom for all -SNAPSHOT versions which have been
   released and replaces them with the corresponding release version. 
   
@@ -162,4 +164,3 @@ Versions Maven Plugin
   * {{{./examples/use-releases.html}Replacing -SNAPSHOT versions with their corresponding releases}}
 
   * {{{./examples/set.html}Changing the project version}}
-

--- a/src/test/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReaderTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReaderTest.java
@@ -1,0 +1,36 @@
+package org.codehaus.mojo.versions.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PropertiesVersionsFileReaderTest {
+
+    private static final String TEST_PROPERTIES_FILE = "src/test/resources/org/codehaus/mojo/versions/utils/testPropertiesVersionsFile.properties";
+
+    @Test
+    public void testRead() throws IOException {
+        PropertiesVersionsFileReader reader = new PropertiesVersionsFileReader(TEST_PROPERTIES_FILE);
+        reader.read();
+
+        int numberOfPropertiesConfig=3;
+        assertTrue(equalsCvsUnordered("booking-api.version,booking-lib.version,be-air-impl.version", reader.getProperties()));
+        assertEquals(numberOfPropertiesConfig, reader.getPropertiesConfig().length);
+    }
+
+    private boolean equalsCvsUnordered(String csvExpected, String csvActual) {
+        if (StringUtils.isEmpty(csvExpected)) {
+            return false;
+        }
+        Set<String> listExpected = new HashSet<String>(Arrays.asList(csvExpected.split(",")));
+        Set<String> listActual = new HashSet<String>(Arrays.asList(csvActual.split(",")));
+        return listExpected.equals(listActual);
+    }
+}

--- a/src/test/resources/org/codehaus/mojo/versions/utils/testPropertiesVersionsFile.properties
+++ b/src/test/resources/org/codehaus/mojo/versions/utils/testPropertiesVersionsFile.properties
@@ -1,0 +1,3 @@
+booking-api.version=1.2.3
+booking-lib.version=4.5.6
+be-air-impl.version=7.8.9


### PR DESCRIPTION
Fixes #469
Possibility to use set-property with `-DpropertiesVersionsFile` to set multiple properties.

Useful to update values of multiples properties in pom with 1 call.

Example:
  ```properties
  #test.properties
  compo1.version=1.2.3
  compo2.version=4.5.6
  ```

  To update all properties in pom.xml in one call:
  ```
    mvn version:set-property -DpropertiesVersionsFile=test.properties
  ```
