### PR TITLE
Configure Release Drafter for Semantic Versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,19 @@
 _extends: .github
-tag-template: versions-maven-plugin-$NEXT_MINOR_VERSION
+name-template: '$RESOLVED_VERSION'
+tag-template: 'versions-maven-plugin-$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+      - enhancement
+  patch:
+    labels:
+      - patch
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* enable version resolver for semantic plugin versioning based on tags
* make sure name-template and tag-template are always in sync
* provide a default release text template
* it's also useful to be able to start the workflow manually when tags are added/updated after the last run