### PR TITLE
Fixed regression in the maven site rendering

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
@@ -97,17 +97,11 @@ public abstract class AbstractVersionsReportRenderer
 
     protected void renderWarningIcon()
     {
-        // a rendering regression was fixed here,
-        // putting figure back will reintroduce the regression.
-        // https://github.com/mojohaus/versions-maven-plugin/issues/536
         sink.figureGraphics( "images/icon_warning_sml.gif" );
     }
 
     protected void renderSuccessIcon()
     {
-        // a rendering regression was fixed here,
-        // putting figure back will reintroduce the regression.
-        // https://github.com/mojohaus/versions-maven-plugin/issues/536
         sink.figureGraphics( "images/icon_success_sml.gif" );
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
@@ -97,16 +97,18 @@ public abstract class AbstractVersionsReportRenderer
 
     protected void renderWarningIcon()
     {
-        sink.figure();
+        // a rendering regression was fixed here,
+        // putting figure back will reintroduce the regression.
+        // https://github.com/mojohaus/versions-maven-plugin/issues/536
         sink.figureGraphics( "images/icon_warning_sml.gif" );
-        sink.figure_();
     }
 
     protected void renderSuccessIcon()
     {
-        sink.figure();
+        // a rendering regression was fixed here,
+        // putting figure back will reintroduce the regression.
+        // https://github.com/mojohaus/versions-maven-plugin/issues/536
         sink.figureGraphics( "images/icon_success_sml.gif" );
-        sink.figure_();
     }
 
     protected boolean equals( ArtifactVersion v1, ArtifactVersion v2 )


### PR DESCRIPTION
https://github.com/mojohaus/versions-maven-plugin/issues/536

Maven Site Plugin and Doxia switching to HTML 5 broke all the reports that includes images.
Including other report plugins.

The proposed fix allows to return back to the original compact format that was more synthetic.