### PR TITLE
#544 set-property: improve validation of plugin parameters:

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -101,12 +101,14 @@ public class SetPropertyMojo
             }
             propertiesConfig = reader.getPropertiesConfig();
             properties = reader.getProperties();
-        } else {
+        } else if (!StringUtils.isEmpty(property)) {
             getLog().debug( "Reading properties and versions to update from property and newVersion " );
             Property propertyConfig = new Property(property);
             propertyConfig.setVersion(newVersion);
             propertiesConfig = new Property[] { propertyConfig };
             properties = property;
+        } else {
+            throw new MojoExecutionException("Please provide either 'property' or 'propertiesVersionsFile' parameter.");
         }
         update(pom, propertiesConfig, properties);
     }
@@ -134,7 +136,7 @@ public class SetPropertyMojo
         if (!StringUtils.isEmpty(property)) {
             getLog().warn("-Dproperty provided but will be ignored as -DpropertiesVersionsFile is used");
         }
-        if (!StringUtils.isEmpty(property)) {
+        if (!StringUtils.isEmpty(newVersion)) {
             getLog().warn("-DnewVersion provided but will be ignored as -DpropertiesVersionsFile is used");
         }
     }


### PR DESCRIPTION
- ensure either 'properties' or 'propertiesVersionFile' is provided
- fix validation of superfluous newVersion parameter

fixes #544 