### PR TITLE
#571 Make use of MessageUtils.getTerminalWidth when displayTerminalWidth is configured to -1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,11 @@
       <version>3.2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.3.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
       <version>${wagonVersion}</version>

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDisplayMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDisplayMojo.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
@@ -65,6 +66,7 @@ public abstract class AbstractVersionsDisplayMojo
 
     /**
      * Terminal width which should be used to format the padding of the version info list output.
+     * If set to -1 the terminal width is detected automatically (may not be supported with all terminals).
      *
      * @since 2.10.0
      */
@@ -165,6 +167,13 @@ public abstract class AbstractVersionsDisplayMojo
      * @return Offset of the configured display terminal width compared to the default with of 80.
      */
     protected int getDisplayTerminalWidthOffset() {
+        if (this.displayTerminalWidth == -1) {
+            this.displayTerminalWidth = MessageUtils.getTerminalWidth();
+            // getTerminalWidth may return -1 if JANSI is not available
+            if (this.displayTerminalWidth == -1) {
+                this.displayTerminalWidth = DEFAULT_DISPLAY_TERMINAL_WIDTH;
+            }
+        }
         return this.displayTerminalWidth - DEFAULT_DISPLAY_TERMINAL_WIDTH;
     }
 


### PR DESCRIPTION
Fixes #571

making use of MessageUtils.getTerminalWidth is _not_ the default behavior. i tested this method on different terminals on windows and got varying results:
* works as expected in powershell and cmd
* does not work in Git bash (the method returned 13249 instead of something about 150 - rendering completely unreadable results).
 
that's probably a bug https://github.com/fusesource/jansi, did not look deeper into this. as Git bash is quite popular on windows i advise not to enable this behavior by default.

@rfscholte WDYT?