### PR TITLE
bugfix for parentVersion wrongly be String "null" when be missing and should be null be default

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
@@ -53,8 +53,7 @@ public class UpdateParentMojo extends AbstractVersionsUpdaterMojo
      *
      * @since 1.0-alpha-1
      */
-    @Parameter( property = "parentVersion",
-                defaultValue = "null" )
+    @Parameter( property = "parentVersion" )
     protected String parentVersion = null;
 
     /**


### PR DESCRIPTION
bugfix for parentVersion wrongly be String "null" when be missing and should be null be default