### PR TITLE
Cache result of getBestFitRule (fixes #575)

### DIFF
--- a/src/it/it-property-updates-report-001/pom.xml
+++ b/src/it/it-property-updates-report-001/pom.xml
@@ -55,25 +55,15 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>@sitePluginVersion@</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>2.1</version>
+          <version>@maven-site-plugin.version@</version>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
   <reporting>
+    <excludeDefaults>true</excludeDefaults>
     <plugins>
-      <plugin>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.1</version>
-        <reportSets>
-          <reportSet/>
-        </reportSets>
-      </plugin>
       <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>

--- a/src/it/it-property-updates-report-002-slow/invoker.properties
+++ b/src/it/it-property-updates-report-002-slow/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=site
+invoker.timeoutInSeconds=30

--- a/src/it/it-property-updates-report-002-slow/maven-version-rules.xml
+++ b/src/it/it-property-updates-report-002-slow/maven-version-rules.xml
@@ -1,0 +1,117 @@
+<ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <rules>
+    <rule groupId="commons-collections">
+      <ignoreVersions>
+        <ignoreVersion type="regex">200[34].*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="com.fasterxml.jackson">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*[.-](rc|pr)\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations">
+      <ignoreVersions>
+        <ignoreVersion type="regex">2\.9\.\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*[.-](rc|pr)\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="com.fasterxml.jackson.jaxrs">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*[.-](rc|pr)\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="com.hazelcast">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-RC\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*-EA\d*</ignoreVersion>
+        <ignoreVersion type="regex">.*-BETA-\d*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="javax.validation">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*\.(Alpha|Beta|CR)\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.camunda.bpm.dmn">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-alpha\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.codehaus.groovy">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-(alpha|beta|rc)-\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.hibernate">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*\.(Alpha|Beta|CR)\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.javassist">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-CR\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.jvnet.jaxb2_commons">
+      <ignoreVersions>
+        <ignoreVersion>1.11.1</ignoreVersion>
+        <ignoreVersion>1.11.1-PUBLISHED-BY-MISTAKE</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.mariadb.jdbc">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-(beta-|RC)\d*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.postgresql">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*\.jre[67]</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.slf4j">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-alpha\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*-beta\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="log4j">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-atlassian-.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.mockito">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-beta(\.\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">.*-RC\.\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.thymeleaf">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*\.(ALPHA|BETA)\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.powermock">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*RC\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*-beta\.\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="com.sun.xml.bind">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-b\d+\.\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="org.glassfish.jaxb">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-b[\d.]+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="junit">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*-beta-\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*-rc-\d+</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
+</ruleset>

--- a/src/it/it-property-updates-report-002-slow/pom.xml
+++ b/src/it/it-property-updates-report-002-slow/pom.xml
@@ -1,0 +1,183 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-property-updates-report-002-slow</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>property-updates-report</name>
+  <description>Validate performance of property-updates-report</description>
+
+  <properties>
+    <spring.version>3.2.17.RELEASE</spring.version>
+    <hibernate-validator.version>4.3.2.Final</hibernate-validator.version>
+    <slf4j.version>1.7.10</slf4j.version>
+    <jaxb.version>2.2.11</jaxb.version>
+    <jaxb2-basics.version>0.11.1</jaxb2-basics.version>
+    <poi.version>3.17</poi.version>
+    <httpclient.version>4.5.2</httpclient.version>
+    <jackson.version>2.6.7.3</jackson.version>
+    <mariadb-client.version>2.4.3</mariadb-client.version>
+    <postgresql-client.version>42.2.6</postgresql-client.version>
+    <groovy.version>2.0.0</groovy.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>${hibernate-validator.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${postgresql-client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mariadb.jdbc</groupId>
+        <artifactId>mariadb-java-client</artifactId>
+        <version>${mariadb-client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>fluent-hc</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient-cache</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpmime</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.poi</groupId>
+        <artifactId>poi-ooxml</artifactId>
+        <version>${poi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.poi</groupId>
+        <artifactId>poi-ooxml-schemas</artifactId>
+        <version>${poi.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>stax</groupId>
+            <artifactId>stax-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-bom</artifactId>
+        <version>${jaxb.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jvnet.jaxb2_commons</groupId>
+        <artifactId>jaxb2-basics-runtime</artifactId>
+        <version>${jaxb2-basics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jvnet.jaxb2_commons</groupId>
+        <artifactId>jaxb2-basics-testing</artifactId>
+        <version>${jaxb2-basics.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <version>${groovy.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>@maven-site-plugin.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rulesUri>file:${project.basedir}/maven-version-rules.xml</rulesUri>
+        </configuration>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>property-updates-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -165,6 +165,14 @@ public class DefaultVersionsHelper
     private final MojoExecution mojoExecution;
 
     /**
+     * A cache mapping artifacts to their best fitting rule, since looking up
+     * this information can be quite costly.
+     * 
+     * @since 2.12
+     */
+    private final Map<String, Rule> artifactBestFitRule = new HashMap<>();
+    
+    /**
      * Constructs a new {@link DefaultVersionsHelper}.
      *
      * @param repositorySystem The repositorySystem.
@@ -522,6 +530,11 @@ public class DefaultVersionsHelper
      */
     protected Rule getBestFitRule( String groupId, String artifactId )
     {
+        String groupArtifactId = groupId + ':' + artifactId;
+        if (artifactBestFitRule.containsKey( groupArtifactId )) {
+            return artifactBestFitRule.get( groupArtifactId );
+        }
+
         Rule bestFit = null;
         final List<Rule> rules = ruleSet.getRules();
         int bestGroupIdScore = Integer.MAX_VALUE;
@@ -571,6 +584,8 @@ public class DefaultVersionsHelper
             }
             bestFit = rule;
         }
+
+        artifactBestFitRule.put( groupArtifactId, bestFit );
         return bestFit;
     }
 


### PR DESCRIPTION
This was identified as a performance hotspot and the result is static
for each run, adding a cache dramatically speeds up some executions.

The included IT shows the problem: Without this optimization, it runs
over a minute, with the fix it finishes instantly.

(Reopened from #365 because I did stupid things with our fork)