### PR TITLE
Fix for issue #648: de-shadowing the localRepository property

### DIFF
--- a/src/it/it-abstract-versions-report-001/invoker.properties
+++ b/src/it/it-abstract-versions-report-001/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:dependency-updates-report
+
+invoker.goals.2=${project.groupId}:${project.artifactId}:${project.version}:plugin-updates-report

--- a/src/it/it-abstract-versions-report-001/pom.xml
+++ b/src/it/it-abstract-versions-report-001/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-abstract-versions-report-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>abstract-versions-report</name>
+  <url>http://localhost/</url>
+
+  <description>
+    Testing command line invocation of dependency- and plugin-updates-report
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-maven-plugin</artifactId>
+        <version>1.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-abstract-versions-report-001/verify.groovy
+++ b/src/it/it-abstract-versions-report-001/verify.groovy
@@ -1,0 +1,15 @@
+dependencyUpdatesReport = new File( basedir, "target/site/dependency-updates-report.html" )
+
+assert dependencyUpdatesReport.exists(  )
+
+// some basic (=not comprehensive) checks on the contents of the dependency report
+assert dependencyUpdatesReport.text =~ /\b1\.1\.0-2\b/  // current version of the dependency
+assert dependencyUpdatesReport.text =~ /\b3\.0\b/       // latest major available version
+
+pluginUpdatesReport = new File( basedir, "target/site/plugin-updates-report.html" )
+
+assert pluginUpdatesReport.exists(  )
+
+// some basic (=not comprehensive) checks on the contents of the plugin report
+assert pluginUpdatesReport.text =~ /\b1\.0\b/        // current version of the plugin
+assert pluginUpdatesReport.text =~ /\b3\.1\b/        // latest major available version

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -19,6 +19,10 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
@@ -43,10 +47,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.DefaultVersionsHelper;
 import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.plexus.i18n.I18N;
-
-import java.io.File;
-import java.util.List;
-import java.util.Locale;
 
 /**
  * Base class for all versions reports.
@@ -101,12 +101,6 @@ public abstract class AbstractVersionsReport
      */
     @Parameter( defaultValue = "${project.pluginArtifactRepositories}", readonly = true )
     protected List<ArtifactRepository> remotePluginRepositories;
-
-    /**
-     * @since 1.0-alpha-1
-     */
-    @Parameter( defaultValue = "${localRepository}", readonly = true )
-    protected ArtifactRepository localRepository;
 
     /**
      * @since 1.0-alpha-3


### PR DESCRIPTION
AbstractMavenReport from maven-reporting-impl:3.2.0 introduced the `localRepository` property, which was supposed to be initialized from a parameter with the same name, and if the same was not supplied, from `${localRepository}`. Unfortunately, it was shadowed by `AbstractVersionsReport`