### PR TITLE
Fix for issue #323: using version range if currentVersion is not available for DependencyUpdatesXmlRenderer

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRenderer.java
@@ -187,8 +187,9 @@ public class DependencyUpdatesXmlRenderer
     public static String getVersionsBlocks( ArtifactVersions versions )
     {
         StringBuilder sBuilder = new StringBuilder();
-        sBuilder.append( TAB ).append( TAB ).append( TAB ).append( wrapElement( versions.getCurrentVersion().toString(),
-                                                                                CURRENT_VERSION ) ).append( NL );
+        sBuilder.append( TAB ).append( TAB ).append( TAB ).append( wrapElement( versions.isCurrentVersionDefined()
+                        ? versions.getCurrentVersion().toString() : versions.getArtifact().getVersionRange().toString(),
+                CURRENT_VERSION ) ).append( NL );
         ArtifactVersion nextVersion = versions.getOldestUpdate( UpdateScope.ANY );
         if ( nextVersion != null )
         {

--- a/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRendererTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRendererTest.java
@@ -1,0 +1,66 @@
+package org.codehaus.mojo.versions;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.IsNull.nullValue;
+
+/**
+ * Basic tests for {@linkplain DependencyUpdatesXmlRenderer}.
+ *
+ * @author Andrzej Jarmoniuk
+ */
+public class DependencyUpdatesXmlRendererTest
+{
+    @Test
+    public void testGetVersionsBlocks() throws InvalidVersionSpecificationException
+    {
+        List<ArtifactVersion> versions =
+                versionsOf( "1.0.0.1", "1.0.0.2", "2.121.2.1", "2.100.0.1", "3.1.0.1", "1.1.1" );
+        final Artifact artifact =
+                new DefaultArtifact( "group", "artifact", VersionRange.createFromVersionSpec( "[1.0,3.0]" ), "foo",
+                        "bar", "jar", null );
+        ArtifactVersions artifactVersions = new ArtifactVersions( artifact, versions, null );
+        assertThat( artifactVersions.getCurrentVersion(), nullValue() );
+        assertThat( artifactVersions.isCurrentVersionDefined(), Is.is( false ) );
+        String versionsBlocks = DependencyUpdatesXmlRenderer.getVersionsBlocks( artifactVersions );
+        assertThat( versionsBlocks, containsString( "<currentVersion>[1.0,3.0]</currentVersion>" ) );
+    }
+
+    private static List<ArtifactVersion> versionsOf( String... versions )
+    {
+        return Arrays.stream( versions ).map( DefaultArtifactVersion::new ).collect( Collectors.toList() );
+    }
+}


### PR DESCRIPTION
DependencyUpdatesXmlRenderer::getVersionsBlocks is used for both dependency and plugins xml report blocks. While the html renderer uses the version as specified in the Dependency class (which is a range if there's no current version specified), the XML renderer only uses an ArtifactVersions object. 

In this PR I'm mimicking the behaviour of the HTML renderer in that regard, i.e. using the range if a concrete version is not given.