### PR TITLE
Fixing #604: npe in DependencyVersionChanger if artifact version is null

### DIFF
--- a/src/it/it-set-024-versionless-dependency/child/pom.xml
+++ b/src/it/it-set-024-versionless-dependency/child/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>child</artifactId>
+
+</project>

--- a/src/it/it-set-024-versionless-dependency/invoker.properties
+++ b/src/it/it-set-024-versionless-dependency/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:set -DprocessDependencies=true, -DartifactId=child -DoldVersion=1.0 -DnewVersion=2.0

--- a/src/it/it-set-024-versionless-dependency/pom.xml
+++ b/src/it/it-set-024-versionless-dependency/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <version>1.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <modules>
+    <module>child</module>
+  </modules>
+</project>

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -354,15 +354,16 @@ public class SetMojo extends AbstractVersionsUpdaterMojo
                 final String mGroupId = PomHelper.getGroupId( m );
                 final String mArtifactId = PomHelper.getArtifactId( m );
                 final String mVersion = PomHelper.getVersion( m );
-                if ( ( ( groupIdRegex.matcher( mGroupId ).matches() && artifactIdRegex.matcher( mArtifactId )
-                    .matches() ) //
-                    || ( processAllModules ) ) //
-                    && oldVersionIdRegex.matcher( mVersion ).matches() && !newVersion.equals( mVersion ) )
+                if ( ( processAllModules
+                        || groupIdRegex.matcher( mGroupId ).matches()
+                        && artifactIdRegex.matcher( mArtifactId ).matches() )
+                        && oldVersionIdRegex.matcher( mVersion ).matches()
+                        && !newVersion.equals( mVersion ) )
                 {
                     found = true;
                     // if the change is not one we have swept up already
                     applyChange( project, reactor, files, mGroupId, m.getArtifactId(),
-                                 StringUtils.isBlank( oldVersion ) || "*".equals( oldVersion ) ? "" : m.getVersion() );
+                            StringUtils.isBlank( oldVersion ) || "*".equals( oldVersion ) ? "" : mVersion );
                 }
             }
             if ( !found && RegexUtils.getWildcardScore( groupId ) == 0 && RegexUtils.getWildcardScore( artifactId ) == 0


### PR DESCRIPTION
Fixing an NPE in DependecyVersionChanger if the old version is null + checkstyle fixes + some minor refactoring.

Edit: There's no verification in that test case as the test is considered successful if no exception is raised :-)