### PR TITLE
Fix: making createMojo return Mojo objects (was previously restricted to SetMojo)

### DIFF
--- a/src/test/java/org/codehaus/mojo/versions/utils/BaseMojoTestCase.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/BaseMojoTestCase.java
@@ -7,9 +7,9 @@ import java.util.Collections;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
-import org.codehaus.mojo.versions.SetMojo;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
@@ -58,11 +58,11 @@ public abstract class BaseMojoTestCase extends AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception thrown if mojo lookup fails
      */
-    protected SetMojo createMojo( String goal, String pomFilePath ) throws Exception
+    protected <T extends Mojo> T createMojo( String goal, String pomFilePath ) throws Exception
     {
         File pomFile = new File( pomFilePath );
-        SetMojo mojo = (SetMojo) lookupMojo( goal, pomFile );
-        mojo.setProject( new TestProjectStub( pomFile ) );
+        T mojo = (T) lookupMojo( goal, pomFile );
+        setVariableValueToObject( mojo, "project", new TestProjectStub( pomFile ) );
         return mojo;
     }
 


### PR DESCRIPTION
A small correction to #656: it was previously restricted to SetMojo only, now making it more generic. A problem is that we're trying to access a property by name, perhaps there should be a common interface instead, but that's for another PR.