### PR TITLE
Fixing #251: proper handling of InvalidSegmentException and InvalidVersionSpecificationException

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/PluginUpdatesDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/PluginUpdatesDetails.java
@@ -58,11 +58,21 @@ public class PluginUpdatesDetails
         return dependencyVersions;
     }
 
+    /**
+     * Returns true if a new version of the artifact fulfilling the criteria (whether to include snapshots) can be found
+     *
+     * @return true if a new version can be found
+     */
     public boolean isArtifactUpdateAvailable()
     {
         return artifactVersions.getAllUpdates( UpdateScope.ANY, includeSnapshots ).length > 0;
     }
 
+    /**
+     * Returns true if a new version of the dependency can be found
+     *
+     * @return true if a new version can be found
+     */
     public boolean isDependencyUpdateAvailable()
     {
         for ( ArtifactVersions versions : dependencyVersions.values() )
@@ -76,6 +86,11 @@ public class PluginUpdatesDetails
         return false;
     }
 
+    /**
+     * Returns true if a new version of the dependency can be found
+     *
+     * @return true if a new version can be found
+     */
     public boolean isUpdateAvailable()
     {
         return isArtifactUpdateAvailable() || isDependencyUpdateAvailable();

--- a/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -37,6 +38,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
+import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 /**
@@ -294,8 +296,15 @@ public class ResolveRangesMojo
 
             int segment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates, allowIncrementalUpdates );
             // TODO: Check if we could add allowDowngrade ? 
-            updatePropertyToNewestVersion( pom, property, version, currentVersion, false, segment );
-
+            try
+            {
+                updatePropertyToNewestVersion( pom, property, version, currentVersion, false, segment );
+            }
+            catch ( InvalidSegmentException | InvalidVersionSpecificationException e )
+            {
+                getLog().warn( String.format( "Skipping the processing of %s:%s due to: %s", property.getName(),
+                        property.getVersion(), e.getMessage() ) );
+            }
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
@@ -24,12 +24,14 @@ import javax.xml.stream.XMLStreamException;
 import java.util.Map;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PropertyVersions;
+import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 /**
@@ -166,20 +168,29 @@ public class UpdatePropertiesMojo extends AbstractVersionsDependencyUpdaterMojo
             {
                 int segment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
                                                          allowIncrementalUpdates );
-                ArtifactVersion targetVersion = updatePropertyToNewestVersion( pom, property, version, currentVersion,
-                                                                               allowDowngrade, segment );
-
-                if ( targetVersion != null )
+                try
                 {
-                    for ( final ArtifactAssociation association : version.getAssociations() )
+                    ArtifactVersion targetVersion =
+                            updatePropertyToNewestVersion( pom, property, version, currentVersion,
+                                    allowDowngrade, segment );
+
+                    if ( targetVersion != null )
                     {
-                        if ( ( isIncluded( association.getArtifact() ) ) )
+                        for ( final ArtifactAssociation association : version.getAssociations() )
                         {
-                            this.getChangeRecorder().recordUpdate( "updateProperty", association.getGroupId(),
-                                                                   association.getArtifactId(), currentVersion,
-                                                                   targetVersion.toString() );
+                            if ( ( isIncluded( association.getArtifact() ) ) )
+                            {
+                                this.getChangeRecorder().recordUpdate( "updateProperty", association.getGroupId(),
+                                        association.getArtifactId(), currentVersion,
+                                        targetVersion.toString() );
+                            }
                         }
                     }
+                }
+                catch ( InvalidSegmentException | InvalidVersionSpecificationException e )
+                {
+                    getLog().warn( String.format( "Skipping the processing of %s:%s due to: %s", property.getName(),
+                            property.getVersion(), e.getMessage() ) );
                 }
             }
 

--- a/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 
 /**
@@ -51,10 +52,18 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                            : versionDetails.getOldestVersion( currentVersion,
-                                                               versionComparator.incrementSegment( currentVersion, 2 ),
-                                                               includeSnapshots, false, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 3
+                        ? null
+                        : versionDetails.getOldestVersion( currentVersion,
+                        versionComparator.incrementSegment( currentVersion, 2 ),
+                        includeSnapshots, false, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -62,10 +71,18 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                            : versionDetails.getNewestVersion( currentVersion,
-                                                               versionComparator.incrementSegment( currentVersion, 2 ),
-                                                               includeSnapshots, false, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 3
+                        ? null
+                        : versionDetails.getNewestVersion( currentVersion,
+                        versionComparator.incrementSegment( currentVersion, 2 ),
+                        includeSnapshots, false, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -73,10 +90,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                            : versionDetails.getVersions( currentVersion,
-                                                          versionComparator.incrementSegment( currentVersion, 2 ),
-                                                          includeSnapshots, false, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
+                                : versionDetails.getVersions( currentVersion,
+                                                              versionComparator.incrementSegment( currentVersion, 2 ),
+                                                              includeSnapshots, false, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
     };
@@ -94,10 +118,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                            : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
-                                                               versionComparator.incrementSegment( currentVersion, 1 ),
-                                                               includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
+                        : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
+                        versionComparator.incrementSegment( currentVersion, 1 ),
+                        includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -105,10 +136,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                            : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
-                                                               versionComparator.incrementSegment( currentVersion, 1 ),
-                                                               includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
+                        : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
+                        versionComparator.incrementSegment( currentVersion, 1 ),
+                        includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -116,10 +154,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                            : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 2 ),
-                                                          versionComparator.incrementSegment( currentVersion, 1 ),
-                                                          includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
+                        : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 2 ),
+                                versionComparator.incrementSegment( currentVersion, 1 ), includeSnapshots, true,
+                                false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
     };
@@ -137,10 +182,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
-                            : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
-                                                               versionComparator.incrementSegment( currentVersion, 0 ),
-                                                               includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
+                        : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
+                        versionComparator.incrementSegment( currentVersion, 0 ),
+                        includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -148,10 +200,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
-                            : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
-                                                               versionComparator.incrementSegment( currentVersion, 0 ),
-                                                               includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
+                        : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
+                                versionComparator.incrementSegment( currentVersion, 0 ), includeSnapshots, true,
+                                false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -159,10 +218,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
-                            : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 1 ),
-                                                          versionComparator.incrementSegment( currentVersion, 0 ),
-                                                          includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
+                        : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 1 ),
+                        versionComparator.incrementSegment( currentVersion, 0 ),
+                        includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
     };
@@ -180,9 +246,16 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
-                            : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 0 ),
-                                                               null, includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
+                        : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 0 ),
+                                                                   null, includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -190,9 +263,16 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
-                            : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 0 ),
-                                                               null, includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
+                        : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 0 ),
+                                                                   null, includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
         /** {@inheritDoc} */
@@ -200,9 +280,17 @@ public abstract class UpdateScope
                                                 boolean includeSnapshots )
         {
             VersionComparator versionComparator = versionDetails.getVersionComparator();
-            return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
-                            : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 0 ), null,
-                                                          includeSnapshots, true, false );
+            try
+            {
+                return versionComparator.getSegmentCount( currentVersion ) < 1
+                        ? null
+                        : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 0 ),
+                        null, includeSnapshots, true, false );
+            }
+            catch ( InvalidSegmentException e )
+            {
+                throw new RuntimeException( e );
+            }
         }
 
     };
@@ -432,6 +520,7 @@ public abstract class UpdateScope
      * @return The update classification.
      */
     public static UpdateScope classifyUpdate( VersionComparator comparator, ArtifactVersion from, ArtifactVersion to )
+            throws InvalidSegmentException
     {
         if ( comparator.compare( from, to ) >= 0 )
         {

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.versions.api;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 
 /**
@@ -266,7 +267,8 @@ public interface VersionDetails
      *         version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getOldestUpdate( ArtifactVersion currentVersion, UpdateScope updateScope );
+    ArtifactVersion getOldestUpdate( ArtifactVersion currentVersion, UpdateScope updateScope )
+            throws InvalidSegmentException;
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
@@ -278,7 +280,8 @@ public interface VersionDetails
      *         version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getNewestUpdate( ArtifactVersion currentVersion, UpdateScope updateScope );
+    ArtifactVersion getNewestUpdate( ArtifactVersion currentVersion, UpdateScope updateScope )
+            throws InvalidSegmentException;
 
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
@@ -288,7 +291,8 @@ public interface VersionDetails
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */
-    ArtifactVersion[] getAllUpdates( ArtifactVersion currentVersion, UpdateScope updateScope );
+    ArtifactVersion[] getAllUpdates( ArtifactVersion currentVersion, UpdateScope updateScope )
+            throws InvalidSegmentException;
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
@@ -302,7 +306,7 @@ public interface VersionDetails
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestUpdate( ArtifactVersion currentVersion, UpdateScope updateScope,
-                                     boolean includeSnapshots );
+                                     boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
@@ -316,7 +320,7 @@ public interface VersionDetails
      * @since 1.0-beta-1
      */
     ArtifactVersion getNewestUpdate( ArtifactVersion currentVersion, UpdateScope updateScope,
-                                     boolean includeSnapshots );
+                                     boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
@@ -328,7 +332,7 @@ public interface VersionDetails
      * @since 1.0-beta-1
      */
     ArtifactVersion[] getAllUpdates( ArtifactVersion currentVersion, UpdateScope updateScope,
-                                     boolean includeSnapshots );
+                                     boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
@@ -449,7 +453,7 @@ public interface VersionDetails
      *         version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getOldestUpdate( UpdateScope updateScope );
+    ArtifactVersion getOldestUpdate( UpdateScope updateScope ) throws InvalidSegmentException;
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
@@ -460,7 +464,7 @@ public interface VersionDetails
      *         version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getNewestUpdate( UpdateScope updateScope );
+    ArtifactVersion getNewestUpdate( UpdateScope updateScope ) throws InvalidSegmentException;
 
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
@@ -469,7 +473,7 @@ public interface VersionDetails
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */
-    ArtifactVersion[] getAllUpdates( UpdateScope updateScope );
+    ArtifactVersion[] getAllUpdates( UpdateScope updateScope ) throws InvalidSegmentException;
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or
@@ -481,7 +485,7 @@ public interface VersionDetails
      *         version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getOldestUpdate( UpdateScope updateScope, boolean includeSnapshots );
+    ArtifactVersion getOldestUpdate( UpdateScope updateScope, boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
      * Returns the newest version newer than the specified current version, but within the the specified update scope or
@@ -493,7 +497,7 @@ public interface VersionDetails
      *         version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getNewestUpdate( UpdateScope updateScope, boolean includeSnapshots );
+    ArtifactVersion getNewestUpdate( UpdateScope updateScope, boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
      * Returns the all versions newer than the specified current version, but within the the specified update scope.
@@ -503,7 +507,7 @@ public interface VersionDetails
      * @return the all versions after currentVersion within the specified update scope.
      * @since 1.0-beta-1
      */
-    ArtifactVersion[] getAllUpdates( UpdateScope updateScope, boolean includeSnapshots );
+    ArtifactVersion[] getAllUpdates( UpdateScope updateScope, boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
      * Returns the oldest version newer than the current version, but within the the specified update scope or

--- a/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
@@ -56,7 +56,7 @@ public abstract class AbstractVersionComparator
     /**
      * {@inheritDoc}
      */
-    public final ArtifactVersion incrementSegment( ArtifactVersion v, int segment )
+    public final ArtifactVersion incrementSegment( ArtifactVersion v, int segment ) throws InvalidSegmentException
     {
         if ( VersionComparators.isSnapshot( v ) )
         {
@@ -66,7 +66,8 @@ public abstract class AbstractVersionComparator
         return innerIncrementSegment( v, segment );
     }
 
-    protected abstract ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment );
+    protected abstract ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment )
+            throws InvalidSegmentException;
 
     /**
      * Returns a hash code value for the comparator class.

--- a/src/main/java/org/codehaus/mojo/versions/ordering/InvalidSegmentException.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/InvalidSegmentException.java
@@ -19,22 +19,56 @@ package org.codehaus.mojo.versions.ordering;
  * under the License.
  */
 
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+
 /**
  * Represents an invalid segment being identified within a version.
  */
-public class InvalidSegmentException
-    extends RuntimeException
+public class InvalidSegmentException extends Exception
 {
+    private final int segment;
+
+    private final int segmentCount;
+
+    private final ArtifactVersion version;
+
     /**
-     * Constructs a new exception.
+     * Constructs the exception object
      *
      * @param segment the invalid segment index.
      * @param segmentCount the number of segments.
-     * @param version the version string.
+     * @param version the version object.
      */
-    public InvalidSegmentException( int segment, int segmentCount, String version )
+    public InvalidSegmentException( int segment, int segmentCount, ArtifactVersion version )
     {
         super( String.format( "Invalid segment, %d, for the %d segment version: '%s'", segment, segmentCount,
-                              version ) );
+                version.toString() ) );
+        this.segment = segment;
+        this.segmentCount = segmentCount;
+        this.version = version;
+    }
+
+    /**
+     * @return segment
+     */
+    public int getSegment()
+    {
+        return segment;
+    }
+
+    /**
+     * @return segment count
+     */
+    public int getSegmentCount()
+    {
+        return segmentCount;
+    }
+
+    /**
+     * @return version object
+     */
+    public ArtifactVersion getVersion()
+    {
+        return version;
     }
 }

--- a/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
@@ -92,12 +92,12 @@ public class MavenVersionComparator
     /**
      * {@inheritDoc}
      */
-    protected ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment )
+    protected ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment ) throws InvalidSegmentException
     {
         int segmentCount = innerGetSegmentCount( v );
         if ( segment < 0 || segment >= segmentCount )
         {
-            throw new InvalidSegmentException( segment, segmentCount, v.toString() );
+            throw new InvalidSegmentException( segment, segmentCount, v );
         }
         String version = v.toString();
         if ( segmentCount == 1 )

--- a/src/main/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparator.java
@@ -52,12 +52,12 @@ public class MercuryVersionComparator
         return tok.countTokens();
     }
 
-    protected ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment )
+    protected ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment ) throws InvalidSegmentException
     {
         final int segmentCount = getSegmentCount( v );
         if ( segment < 0 || segment > segmentCount )
         {
-            throw new InvalidSegmentException( segment, segmentCount, v.toString() );
+            throw new InvalidSegmentException( segment, segmentCount, v );
         }
         final String version = v.toString();
         StringBuilder result = new StringBuilder( version.length() + 10 );

--- a/src/main/java/org/codehaus/mojo/versions/ordering/NumericVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/NumericVersionComparator.java
@@ -163,12 +163,12 @@ public class NumericVersionComparator
      * {@inheritDoc}
      */
     @SuppressWarnings( "checkstyle:MethodLength" )
-    protected ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment )
+    protected ArtifactVersion innerIncrementSegment( ArtifactVersion v, int segment ) throws InvalidSegmentException
     {
         final int segmentCount = innerGetSegmentCount( v );
         if ( segment < 0 || segment > segmentCount )
         {
-            throw new InvalidSegmentException( segment, segmentCount, v.toString() );
+            throw new InvalidSegmentException( segment, segmentCount, v );
         }
         final String version = v.toString();
         StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codehaus/mojo/versions/ordering/VersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/VersionComparator.java
@@ -46,5 +46,5 @@ public interface VersionComparator
      * @return An artifact version with the specified segment incremented.
      * @since 1.0-beta-1
      */
-    ArtifactVersion incrementSegment( ArtifactVersion artifactVersion, int segment );
+    ArtifactVersion incrementSegment( ArtifactVersion artifactVersion, int segment ) throws InvalidSegmentException;
 }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/MavenVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/MavenVersionComparatorTest.java
@@ -42,7 +42,7 @@ public class MavenVersionComparatorTest
 
     @Test
     public void testSegmentIncrementing()
-        throws Exception
+        throws InvalidSegmentException
     {
         assertIncrement( "6", "5", 0 );
         assertIncrement( "6.0", "5.0", 0 );
@@ -58,7 +58,7 @@ public class MavenVersionComparatorTest
         assertIncrement( "1.0-z90-SNAPSHOT", "1.0-z9-SNAPSHOT", 3 );
     }
 
-    private void assertIncrement( String expected, String initial, int segment )
+    private void assertIncrement( String expected, String initial, int segment ) throws InvalidSegmentException
     {
         assertEquals( expected,
                       instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );

--- a/src/test/java/org/codehaus/mojo/versions/ordering/VersionComparatorsTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/VersionComparatorsTest.java
@@ -38,24 +38,24 @@ public class VersionComparatorsTest
     };
 
     @Test
-    public void testMavenVersionComparator()
+    public void testMavenVersionComparator() throws InvalidSegmentException
     {
         assertVersions( new MavenVersionComparator() );
     }
 
     @Test
-    public void testMercuryVersionComparator()
+    public void testMercuryVersionComparator() throws InvalidSegmentException
     {
         assertVersions( new MercuryVersionComparator() );
     }
 
     @Test
-    public void testNumericVersionComparator()
+    public void testNumericVersionComparator() throws InvalidSegmentException
     {
         assertVersions( new NumericVersionComparator() );
     }
 
-    public void assertVersions( VersionComparator instance )
+    public void assertVersions( VersionComparator instance ) throws InvalidSegmentException
     {
         for ( int i = 0; i < versionDataset.length; i++ )
         {
@@ -64,7 +64,7 @@ public class VersionComparatorsTest
         }
     }
 
-    public void assertLater( String version, VersionComparator instance )
+    public void assertLater( String version, VersionComparator instance ) throws InvalidSegmentException
     {
         ArtifactVersion v1 = new DefaultArtifactVersion( version );
         int count = instance.getSegmentCount( v1 );


### PR DESCRIPTION
The situations indicated in the exceptions were not handled properly throughout the code, in some places, `MojoExcecutionException` was simply being thrown leading to the whole run being stopped; `InvalidVersionSpecificationException` was unchecked, leading to the same.

Handling those situations in the Mojo itself rather than in the methods so that a proper handling could be effected where necessary.

Because of all that, a rather sizeable refactoring was due.

More PRs will follow, I want to refactor and polish the code more, but this one is what's necessary for resolving this issue.

So, like I said in the linked issue:

The more I look into it, the more issues I see:

- segment appears to be 0-based (see e.g. `AbstractVersionsUpaterMojo.determineUnchangedSegment` or `MavenVersionComparator.innerIncrementSegment`), but the comparison against the segment count suffers from the 1-off problem:
```java
if ( segment > segmentCount )
{
    throw new InvalidSegmentException( segment, segmentCount,
            version.toString() );
}
```
- segment determination flags (allowMajorUpdates, etc.) are actually not at all independent, but are actually a sort of enum; so an actual enum or an unchanged segment index would be better;
- part of the above: it's not actually possible to have allowMajorUpdates = true and allowMinorUpdates = false; allowMajorUpdates = true implies all others also being true;

There are probably more problems with this, but I'll limit the scope of this item to the issue OP raised only. **The other findings will be done as separate issues.**