### PR TITLE
#632 Fixed lower and upper bounds to keep milestones and rcs in the right majors.

### DIFF
--- a/src/it/it-dependency-updates-report-001/verify.bsh
+++ b/src/it/it-dependency-updates-report-001/verify.bsh
@@ -17,7 +17,7 @@ try
         System.out.println( "Result = \"" + result +"\"" );
         return false;
     }
-    if ( result.indexOf( "1.1.0-2 Next Version" ) < 0)
+    if ( result.indexOf( "1.1.0-2 Latest Subincremental" ) < 0)
     {
         System.out.println( "Did not identify next version" );
         System.out.println( "Result = \"" + result +"\"" );

--- a/src/it/it-plugin-updates-report-001/verify.bsh
+++ b/src/it/it-plugin-updates-report-001/verify.bsh
@@ -39,7 +39,7 @@ try
         return false;
     }
     if ( result.indexOf( "Group Id localhost Artifact Id dummy-api Current Version 1.1 Classifier Type jar Newer "
-            + "versions 1.1.0-2 Next Version 1.1.1 Next Incremental 1.1.1-2 1.1.2 1.1.3 Latest Incremental 1.2 Next "
+            + "versions 1.1.0-2 Latest Subincremental 1.1.1 Next Incremental 1.1.1-2 1.1.2 1.1.3 Latest Incremental 1.2 Next "
             + "Minor 1.2.1 1.2.2 1.3 Latest Minor 2.0 Next Major 2.1 3.0 Latest Major" ) < 0)
     {
         System.out.println( "Did not identify dependency next versions" );

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
@@ -33,6 +33,7 @@ import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.reporting.AbstractMavenReportRenderer;
+import org.codehaus.mojo.versions.api.AbstractVersionDetails;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PropertyVersions;
@@ -432,57 +433,18 @@ public abstract class AbstractVersionsReportRenderer
                 {
                     sink.lineBreak();
                 }
-                boolean bold = equals( versions[i], details.getOldestUpdate( of( SUBINCREMENTAL ) ) )
-                    || equals( versions[i], details.getNewestUpdate( of( SUBINCREMENTAL ) ) )
-                    || equals( versions[i], details.getOldestUpdate( of( INCREMENTAL ) ) )
-                    || equals( versions[i], details.getNewestUpdate( of( INCREMENTAL ) ) )
-                    || equals( versions[i], details.getOldestUpdate( of( MINOR ) ) )
-                    || equals( versions[i], details.getNewestUpdate( of( MINOR ) ) )
-                    || equals( versions[i], details.getOldestUpdate( of( MAJOR ) ) )
-                    || equals( versions[i], details.getNewestUpdate( of( MAJOR ) ) );
-                if ( bold )
+                String label = getLabel( versions[i], details );
+                if ( label != null )
                 {
                     safeBold();
                 }
                 sink.text( versions[i].toString() );
-                if ( bold )
+                if ( label != null )
                 {
                     safeBold_();
                     sink.nonBreakingSpace();
                     safeItalic();
-                    if ( equals( versions[i], details.getOldestUpdate( of( SUBINCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.nextVersion" ) );
-                    }
-                    else if ( equals( versions[i], details.getNewestUpdate( of( SUBINCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.latestSubIncremental" ) );
-                    }
-                    else if ( equals( versions[i], details.getOldestUpdate( of( INCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.nextIncremental" ) );
-                    }
-                    else if ( equals( versions[i], details.getNewestUpdate( of( INCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.latestIncremental" ) );
-                    }
-                    else if ( equals( versions[i], details.getOldestUpdate( of( MINOR ) ) ) )
-                    {
-                        sink.text( getText( "report.nextMinor" ) );
-                    }
-                    else if ( equals( versions[i], details.getNewestUpdate( of( MINOR ) ) ) )
-                    {
-                        sink.text( getText( "report.latestMinor" ) );
-                    }
-                    else if ( equals( versions[i], details.getOldestUpdate( of( MAJOR ) ) ) )
-                    {
-                        sink.text( getText( "report.nextMajor" ) );
-                    }
-                    else if ( equals( versions[i], details.getNewestUpdate( of( MAJOR ) ) ) )
-                    {
-                        sink.text( getText( "report.latestMajor" ) );
-                    }
-
+                    sink.text( label );
                     safeItalic_();
                 }
             }
@@ -707,25 +669,18 @@ public abstract class AbstractVersionsReportRenderer
                     sink.lineBreak();
                 }
                 boolean allowed = ( rangeVersions.contains( artifactVersions[i].toString() ) );
-                boolean bold = equals( artifactVersions[i], versions.getOldestUpdate( of( SUBINCREMENTAL ) ) )
-                    || equals( artifactVersions[i], versions.getNewestUpdate( of( SUBINCREMENTAL ) ) )
-                    || equals( artifactVersions[i], versions.getOldestUpdate( of( INCREMENTAL ) ) )
-                    || equals( artifactVersions[i], versions.getNewestUpdate( of( INCREMENTAL ) ) )
-                    || equals( artifactVersions[i], versions.getOldestUpdate( of( MINOR ) ) )
-                    || equals( artifactVersions[i], versions.getNewestUpdate( of( MINOR ) ) )
-                    || equals( artifactVersions[i], versions.getOldestUpdate( of( MAJOR ) ) )
-                    || equals( artifactVersions[i], versions.getNewestUpdate( of( MAJOR ) ) );
+                String label = getLabel( artifactVersions[i], versions );
                 if ( !allowed )
                 {
                     sink.text( "* " );
                     someNotAllowed = true;
                 }
-                if ( allowed && bold )
+                if ( allowed && label != null )
                 {
                     safeBold();
                 }
                 sink.text( artifactVersions[i].toString() );
-                if ( bold )
+                if ( label != null )
                 {
                     if ( allowed )
                     {
@@ -733,39 +688,7 @@ public abstract class AbstractVersionsReportRenderer
                     }
                     sink.nonBreakingSpace();
                     safeItalic();
-                    if ( equals( artifactVersions[i], versions.getOldestUpdate( of( SUBINCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.nextVersion" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getNewestUpdate( of( SUBINCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.latestSubIncremental" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getOldestUpdate( of( INCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.nextIncremental" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getNewestUpdate( of( INCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.latestIncremental" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getOldestUpdate( of( MINOR ) ) ) )
-                    {
-                        sink.text( getText( "report.nextMinor" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getNewestUpdate( of( MINOR ) ) ) )
-                    {
-                        sink.text( getText( "report.latestMinor" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getOldestUpdate( of( MAJOR ) ) ) )
-                    {
-                        sink.text( getText( "report.nextMajor" ) );
-                    }
-                    else if ( equals( artifactVersions[i], versions.getNewestUpdate( of( MAJOR ) ) ) )
-                    {
-                        sink.text( getText( "report.latestMajor" ) );
-                    }
-
+                    sink.text( label );
                     safeItalic_();
                 }
             }
@@ -853,6 +776,44 @@ public abstract class AbstractVersionsReportRenderer
             rangeVersions.add( artifactVersion.toString() );
         }
         return rangeVersions;
+    }
+
+    protected String getLabel( ArtifactVersion version, AbstractVersionDetails versions )
+    {
+        String label = null;
+        if ( equals( version, versions.getNewestUpdate( of( MAJOR ) ) ) )
+        {
+            label = getText( "report.latestMajor" );
+        }
+        else if ( equals( version, versions.getOldestUpdate( of( MAJOR ) ) ) )
+        {
+            label = getText( "report.nextMajor" );
+        }
+        else if ( equals( version, versions.getNewestUpdate( of( MINOR ) ) ) )
+        {
+            label = getText( "report.latestMinor" );
+        }
+        else if ( equals( version, versions.getOldestUpdate( of( MINOR ) ) ) )
+        {
+            label = getText( "report.nextMinor" );
+        }
+        else if ( equals( version, versions.getNewestUpdate( of( INCREMENTAL ) ) ) )
+        {
+            label = getText( "report.latestIncremental" );
+        }
+        else if ( equals( version, versions.getOldestUpdate( of( INCREMENTAL ) ) ) )
+        {
+            label = getText( "report.nextIncremental" );
+        }
+        else if ( equals( version, versions.getNewestUpdate( of( SUBINCREMENTAL ) ) ) )
+        {
+            label = getText( "report.latestSubIncremental" );
+        }
+        else if ( equals( version, versions.getOldestUpdate( of( SUBINCREMENTAL ) ) ) )
+        {
+            label = getText( "report.nextVersion" );
+        }
+        return label;
     }
 
 }

--- a/src/main/java/org/codehaus/mojo/versions/PluginUpdatesRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/PluginUpdatesRenderer.java
@@ -436,67 +436,18 @@ public class PluginUpdatesRenderer
                 {
                     sink.lineBreak();
                 }
-                boolean bold = equals(
-                    versions[i], details.getArtifactVersions().getOldestUpdate( of( SUBINCREMENTAL ) ) )
-                    || equals( versions[i],
-                               details.getArtifactVersions().getNewestUpdate( of( SUBINCREMENTAL ) ) )
-                    || equals( versions[i], details.getArtifactVersions().getOldestUpdate( of( INCREMENTAL ) ) )
-                    || equals( versions[i], details.getArtifactVersions().getNewestUpdate( of( INCREMENTAL ) ) )
-                    || equals( versions[i], details.getArtifactVersions().getOldestUpdate( of( MINOR ) ) )
-                    || equals( versions[i], details.getArtifactVersions().getNewestUpdate( of( MINOR ) ) )
-                    || equals( versions[i], details.getArtifactVersions().getOldestUpdate( of( MAJOR ) ) )
-                    || equals( versions[i], details.getArtifactVersions().getNewestUpdate( of( MAJOR ) ) );
-                if ( bold )
+                String label = getLabel( versions[i], details.getArtifactVersions() );
+                if ( label != null )
                 {
                     safeBold();
                 }
                 sink.text( versions[i].toString() );
-                if ( bold )
+                if ( label != null )
                 {
                     safeBold_();
                     sink.nonBreakingSpace();
                     safeItalic();
-                    if ( equals( versions[i],
-                                 details.getArtifactVersions().getOldestUpdate( of( SUBINCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.nextVersion" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getNewestUpdate( of( SUBINCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.latestSubIncremental" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getOldestUpdate( of( INCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.nextIncremental" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getNewestUpdate( of( INCREMENTAL ) ) ) )
-                    {
-                        sink.text( getText( "report.latestIncremental" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getOldestUpdate( of( MINOR ) ) ) )
-                    {
-                        sink.text( getText( "report.nextMinor" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getNewestUpdate( of( MINOR ) ) ) )
-                    {
-                        sink.text( getText( "report.latestMinor" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getOldestUpdate( of( MAJOR ) ) ) )
-                    {
-                        sink.text( getText( "report.nextMajor" ) );
-                    }
-                    else if ( equals( versions[i],
-                                      details.getArtifactVersions().getNewestUpdate( of( MAJOR ) ) ) )
-                    {
-                        sink.text( getText( "report.latestMajor" ) );
-                    }
-
+                    sink.text( label );
                     safeItalic_();
                 }
             }

--- a/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -507,7 +507,7 @@ public abstract class AbstractVersionDetails
      * Checks if the candidate version is in the range of the restriction.
      * a custom comparator is/can be used to have milestones and rcs before final releases,
      * which is not yet possible with {@link Restriction#containsVersion(ArtifactVersion)}.
-     * @PARAM RESTRICTION THE RANGE TO CHECK AGAINST.
+     * @param restriction the range to check against.
      * @param candidate the version to check.
      * @return true if the candidate version is within the range of the restriction parameter.
      */

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -213,7 +213,7 @@ public interface VersionDetails
     ArtifactVersion getOldestVersion( VersionRange versionRange, Restriction restriction, boolean includeSnapshots );
 
     /**
-     * Returns the oldest version newer than the specified current version, but within the the specified update scope or
+     * Returns the oldest version newer than the specified current version, but within the specified update scope or
      * <code>null</code> if no such version exists.
      *
      * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
@@ -227,7 +227,7 @@ public interface VersionDetails
                                      boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
-     * Returns the newest version newer than the specified current version, but within the the specified update scope or
+     * Returns the newest version newer than the specified current version, but within the specified update scope or
      * <code>null</code> if no such version exists.
      *
      * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
@@ -241,7 +241,7 @@ public interface VersionDetails
                                      boolean includeSnapshots ) throws InvalidSegmentException;
 
     /**
-     * Returns the all versions newer than the specified current version, but within the the specified update scope.
+     * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param currentVersion the lower bound or <code>null</code> if the lower limit is unbounded.
      * @param updateScope the update scope to include.
@@ -289,7 +289,7 @@ public interface VersionDetails
     ArtifactVersion getCurrentVersion();
 
     /**
-     * Returns the oldest version newer than the current version, but within the the specified update scope or
+     * Returns the oldest version newer than the current version, but within the specified update scope or
      * <code>null</code> if no such version exists.
      *
      * @param updateScope the update scope to include.
@@ -300,7 +300,7 @@ public interface VersionDetails
     ArtifactVersion getOldestUpdate( Optional<Segment> updateScope ) throws InvalidSegmentException;
 
     /**
-     * Returns the newest version newer than the specified current version, but within the the specified update scope or
+     * Returns the newest version newer than the specified current version, but within the specified update scope or
      * <code>null</code> if no such version exists.
      *
      * @param updateScope the update scope to include.
@@ -311,7 +311,7 @@ public interface VersionDetails
     ArtifactVersion getNewestUpdate( Optional<Segment> updateScope ) throws InvalidSegmentException;
 
     /**
-     * Returns the all versions newer than the specified current version, but within the the specified update scope.
+     * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param updateScope the update scope to include.
      * @return the all versions after currentVersion within the specified update scope.
@@ -320,7 +320,7 @@ public interface VersionDetails
     ArtifactVersion[] getAllUpdates( Optional<Segment> updateScope ) throws InvalidSegmentException;
 
     /**
-     * Returns the oldest version newer than the specified current version, but within the the specified update scope or
+     * Returns the oldest version newer than the specified current version, but within the specified update scope or
      * <code>null</code> if no such version exists.
      *
      * @param updateScope the update scope to include.
@@ -333,7 +333,7 @@ public interface VersionDetails
             throws InvalidSegmentException;
 
     /**
-     * Returns the newest version newer than the specified current version, but within the the specified update scope or
+     * Returns the newest version newer than the specified current version, but within the specified update scope or
      * <code>null</code> if no such version exists.
      *
      * @param updateScope the update scope to include.
@@ -346,7 +346,7 @@ public interface VersionDetails
             throws InvalidSegmentException;
 
     /**
-     * Returns the all versions newer than the specified current version, but within the the specified update scope.
+     * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param updateScope the update scope to include.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
@@ -357,7 +357,7 @@ public interface VersionDetails
             throws InvalidSegmentException;
 
     /**
-     * Returns the all versions newer than the specified current version, but within the the specified update scope.
+     * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param versionRange the version range to include.
      * @return the all versions after currentVersion within the specified update scope.
@@ -366,7 +366,7 @@ public interface VersionDetails
     ArtifactVersion[] getAllUpdates( VersionRange versionRange );
 
     /**
-     * Returns the all versions newer than the specified current version, but within the the specified update scope.
+     * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param versionRange the version range to include.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.

--- a/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
@@ -59,17 +59,8 @@ public abstract class AbstractVersionComparator
      */
     public final ArtifactVersion incrementSegment( ArtifactVersion v, Segment segment ) throws InvalidSegmentException
     {
-        if ( VersionComparators.isSnapshot( v ) )
-        {
-            return VersionComparators.copySnapshot( v, innerIncrementSegment( VersionComparators.stripSnapshot( v ),
-                                                                              segment ) );
-        }
-        int segmentCount = getSegmentCount( v );
-        if ( segment.value() >= segmentCount )
-        {
-            throw new InvalidSegmentException( segment, segmentCount, v );
-        }
-        return innerIncrementSegment( v, segment );
+        return VersionComparators.copySnapshot( v, innerIncrementSegment( VersionComparators.stripSnapshot( v ),
+                                                                          segment ) );
     }
 
     protected abstract ArtifactVersion innerIncrementSegment( ArtifactVersion v, Segment segment )

--- a/src/main/java/org/codehaus/mojo/versions/ordering/ComparableVersion.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/ComparableVersion.java
@@ -127,7 +127,8 @@ public class ComparableVersion
     private static class StringItem
         implements Item
     {
-        private static final String[] QUALIFIERS = {"snapshot", "alpha", "beta", "milestone", "rc", "", "sp"};
+        private static final String[] QUALIFIERS = {
+                "snapshot", "alpha", "beta", "milestone", "preview", "rc", "", "sp" };
 
         private static final List<String> QUALIFIERS_LIST = Arrays.asList( QUALIFIERS );
 
@@ -135,9 +136,10 @@ public class ComparableVersion
 
         static
         {
-            ALIASES.put( "ga", "" );
-            ALIASES.put( "final", "" );
+            ALIASES.put( "mr", "milestone" );
             ALIASES.put( "cr", "rc" );
+            ALIASES.put( "final", "" );
+            ALIASES.put( "ga", "" );
         }
 
         /**

--- a/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
@@ -38,7 +38,7 @@ public class MavenVersionComparator extends AbstractVersionComparator
      */
     public int compare( ArtifactVersion o1, ArtifactVersion o2 )
     {
-        return o1.compareTo( o2 );
+        return new ComparableVersion( o1.toString() ).compareTo( new ComparableVersion( o2.toString() ) );
     }
 
     /**

--- a/src/test/java/org/codehaus/mojo/versions/ordering/MavenVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/MavenVersionComparatorTest.java
@@ -45,8 +45,7 @@ public class MavenVersionComparatorTest
     }
 
     @Test
-    public void testSegmentIncrementing()
-        throws InvalidSegmentException
+    public void testSegmentIncrementing() throws InvalidSegmentException
     {
         assertIncrement( "6", "5", MAJOR );
         assertIncrement( "6.0", "5.0", MAJOR );
@@ -56,15 +55,15 @@ public class MavenVersionComparatorTest
         assertIncrement( "5.alpha-1.2", "5.alpha-1.1", MAJOR );
         assertIncrement( "5.alpha-1.ba", "5.alpha-1.az", MAJOR );
         assertIncrement( "5.alpha-wins.2", "5.alpha-wins.1", MAJOR );
-        assertIncrement( "1.0-alpha-3-SNAPSHOT", "1.0-alpha-2-SNAPSHOT", SUBINCREMENTAL );
-        assertIncrement( "1.0-alpha-90-SNAPSHOT", "1.0-alpha-9-SNAPSHOT", SUBINCREMENTAL );
-        assertIncrement( "1.0-za-SNAPSHOT", "1.0-z-SNAPSHOT", SUBINCREMENTAL );
-        assertIncrement( "1.0-z90-SNAPSHOT", "1.0-z9-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-alpha-3", "1.0-alpha-2-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-alpha-90", "1.0-alpha-9-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-za", "1.0-z-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-z90", "1.0-z9-SNAPSHOT", SUBINCREMENTAL );
     }
 
     private void assertIncrement( String expected, String initial, Segment segment ) throws InvalidSegmentException
     {
-        assertEquals( expected,
+        assertEquals( expected + "-SNAPSHOT",
                       instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparatorTest.java
@@ -20,6 +20,7 @@ package org.codehaus.mojo.versions.ordering;
  */
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.mojo.versions.api.Segment;
 import org.junit.Test;
 
 import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
@@ -32,8 +33,7 @@ public class MercuryVersionComparatorTest
     private MercuryVersionComparator instance = new MercuryVersionComparator();
 
     @Test
-    public void testSegmentCounting()
-            throws Exception
+    public void testSegmentCounting() throws Exception
     {
         assertEquals( 1, instance.getSegmentCount( new DefaultArtifactVersion( "5" ) ) );
         assertEquals( 2, instance.getSegmentCount( new DefaultArtifactVersion( "5.0" ) ) );
@@ -44,24 +44,21 @@ public class MercuryVersionComparatorTest
     }
 
     @Test
-    public void testSegmentIncrementing()
-            throws Exception
+    public void testSegmentIncrementing() throws Exception
     {
-        assertEquals( new DefaultArtifactVersion( "6" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5" ), MAJOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "6.0" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MAJOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.1" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.1.0" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.0.1" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.beta.0" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha.1" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.beta-0.0" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.alpha-2.0" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), INCREMENTAL ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.beta-0.0" ).toString(),
-                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-wins.1" ), MINOR ).toString() );
+        assertIncrement( "6", "5", MAJOR );
+        assertIncrement( "6.0", "5.0", MAJOR );
+        assertIncrement( "5.1", "5.0", MINOR );
+        assertIncrement( "5.1.0", "5.0.1", MINOR );
+        assertIncrement( "5.beta.0", "5.alpha.1", MINOR );
+        assertIncrement( "5.beta-0.0", "5.alpha-1.1", MINOR );
+        assertIncrement( "5.alpha-2.0", "5.alpha-1.1", INCREMENTAL );
+        assertIncrement( "5.beta-0.0", "5.alpha-wins.1", MINOR );
+    }
+
+    private void assertIncrement( String expected, String initial, Segment segment ) throws InvalidSegmentException
+    {
+        assertEquals( expected + "-SNAPSHOT",
+                      instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/NumericVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/NumericVersionComparatorTest.java
@@ -20,6 +20,7 @@ package org.codehaus.mojo.versions.ordering;
  */
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.mojo.versions.api.Segment;
 import org.junit.Test;
 
 import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
@@ -103,25 +104,21 @@ public class NumericVersionComparatorTest
     }
 
     @Test
-    public void testSegmentIncrementing()
-        throws Exception
+    public void testSegmentIncrementing() throws Exception
     {
-        assertEquals( new DefaultArtifactVersion( "6" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5" ), MAJOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "6.0" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MAJOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.1" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.1.0" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.0.1" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.beta.0" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha.1" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.alpha-2.0" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), MINOR ).toString() );
-        assertEquals( new DefaultArtifactVersion( "5.alpha-1.2" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), INCREMENTAL )
-                              .toString() );
-        assertEquals( new DefaultArtifactVersion( "5.beta.0" ).toString(),
-                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-wins.1" ), MINOR ).toString() );
+        assertIncrement( "6", "5", MAJOR );
+        assertIncrement( "6.0", "5.0", MAJOR );
+        assertIncrement( "5.1", "5.0", MINOR );
+        assertIncrement( "5.1.0", "5.0.1", MINOR );
+        assertIncrement( "5.beta.0", "5.alpha.1", MINOR );
+        assertIncrement( "5.alpha-2.0", "5.alpha-1.1", MINOR );
+        assertIncrement( "5.alpha-1.2", "5.alpha-1.1", INCREMENTAL );
+        assertIncrement( "5.beta.0", "5.alpha-wins.1", MINOR );
+    }
+
+    private void assertIncrement( String expected, String initial, Segment segment ) throws InvalidSegmentException
+    {
+        assertEquals( expected + "-SNAPSHOT",
+                      instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );
     }
 }


### PR DESCRIPTION
#632 Fix Bounds so lower and upper bounds keep milestones and rcs in the same majors when they are.

a quick before/after : 

![image](https://user-images.githubusercontent.com/5782559/188847011-aa41c4dc-2e02-4fae-9aba-b5d6c3152f2b.png)
![image](https://user-images.githubusercontent.com/5782559/188888515-929d73a2-ad30-4a61-a470-bee487d1b7ec.png)
