### PR TITLE
#673: Fixing NPE in UseDepVersionMojo caused by PatternIncludesArtifactFilter expecting a non-null classifier when using wildcards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-common-artifact-filters</artifactId>
-      <version>3.3.1</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
@@ -272,6 +272,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/codehaus/mojo/versions/UseDepVersionMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/UseDepVersionMojoTest.java
@@ -1,0 +1,47 @@
+package org.codehaus.mojo.versions;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+
+import org.codehaus.mojo.versions.utils.BaseMojoTestCase;
+import org.junit.Test;
+
+/**
+ * Basic tests for {@linkplain UseDepVersionMojo}.
+ *
+ * @author Andrzej Jarmoniuk
+ */
+public class UseDepVersionMojoTest extends BaseMojoTestCase
+{
+    @Test
+    public void testIssue673() throws Exception
+    {
+        UseDepVersionMojo mojo = createMojo( "use-dep-version",
+                "src/test/resources/org/codehaus/mojo/use-dep-version/issue-637-pom.xml" );
+        setVariableValueToObject( mojo, "processDependencies", true );
+        setVariableValueToObject( mojo, "processDependencyManagement", true );
+        setVariableValueToObject( mojo, "excludeReactor", true );
+        setVariableValueToObject( mojo, "serverId", "serverId" );
+        setVariableValueToObject( mojo, "reactorProjects", Collections.singletonList( mojo.getProject() ) );
+
+        mojo.execute();
+    }
+}

--- a/src/test/java/org/codehaus/mojo/versions/utils/BaseMojoTestCase.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/BaseMojoTestCase.java
@@ -3,9 +3,12 @@ package org.codehaus.mojo.versions.utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.plugin.Mojo;
@@ -116,6 +119,18 @@ public abstract class BaseMojoTestCase extends AbstractMojoTestCase
         public Properties getProperties()
         {
             return getModel().getProperties();
+        }
+
+        @Override
+        public List<Dependency> getDependencies()
+        {
+            return getModel().getDependencies();
+        }
+
+        @Override
+        public DependencyManagement getDependencyManagement()
+        {
+            return getModel().getDependencyManagement();
         }
     }
 }

--- a/src/test/resources/org/codehaus/mojo/use-dep-version/issue-637-pom.xml
+++ b/src/test/resources/org/codehaus/mojo/use-dep-version/issue-637-pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>dep-artifact</artifactId>
+            <version>22.09.21</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <depVersion>DEVELOP-SNAPSHOT</depVersion>
+                    <includesList>test-group*:::JET*-SNAPSHOT</includesList>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Reason for the NPE: the new version of maven-common-artifact-filters, class `PatternIncludesArtifactFilters` (line 593) expects the "artifactoid" to return a non-null value for every field when the pattern contains a wildcard character.

The "artifactoid" is a functional interface basically returning the desired segment (coordinate in the code) of the artifact. The classifer is not set, hence equal null; this leads to NPE.