### PR TITLE
Issue 610 update-parent: add a possibility to skip version resolution and enforce a parent version

### DIFF
--- a/src/it/it-update-parent-005-issue-610/invoker.properties
+++ b/src/it/it-update-parent-005-issue-610/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:update-parent
+invoker.mavenOpts = -DparentVersion=999 -DskipResolution=true

--- a/src/it/it-update-parent-005-issue-610/pom.xml
+++ b/src/it/it-update-parent-005-issue-610/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-parent4</artifactId>
+        <version>70</version>
+    </parent>
+
+    <groupId>localhsot</groupId>
+    <artifactId>issue-670</artifactId>
+    <version>0.31-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+</project>

--- a/src/it/it-update-parent-005-issue-610/verify.groovy
+++ b/src/it/it-update-parent-005-issue-610/verify.groovy
@@ -1,0 +1,3 @@
+pom = new File( basedir, "pom.xml" ).text
+
+assert pom =~ /<version>999<\/version>/


### PR DESCRIPTION
As explained in #610 

If `parentVersion` is set, `skipResolution` will cause the mojo to completely skip version resolution and will simply set the parent version to the given version. 

Added tests + enhanced the documentation.