### PR TITLE
Restriction parameter to prevent more than 7 parameters in the next PRs

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -234,18 +234,10 @@ public abstract class AbstractVersionsReport
      * @since 1.0-alpha-1
      */
     protected ArtifactVersion findLatestVersion( Artifact artifact, VersionRange versionRange,
-                                                 boolean allowingSnapshots, boolean usePluginRepositories )
+                                                 Boolean allowingSnapshots, boolean usePluginRepositories )
         throws MavenReportException
     {
-        boolean includeSnapshots = this.allowSnapshots;
-        if ( allowingSnapshots )
-        {
-            includeSnapshots = true;
-        }
-        if ( allowingSnapshots )
-        {
-            includeSnapshots = false;
-        }
+        boolean includeSnapshots = allowingSnapshots != null ? allowingSnapshots : this.allowSnapshots;
         try
         {
             final ArtifactVersions artifactVersions =

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -313,18 +313,9 @@ public abstract class AbstractVersionsUpdaterMojo
                                                  boolean allowDowngrade )
         throws ArtifactMetadataRetrievalException, MojoExecutionException
     {
-        boolean includeSnapshots = this.allowSnapshots;
-        if ( Boolean.TRUE.equals( allowingSnapshots ) )
-        {
-            includeSnapshots = true;
-        }
-        if ( Boolean.FALSE.equals( allowingSnapshots ) )
-        {
-            includeSnapshots = false;
-        }
+        boolean includeSnapshots = allowingSnapshots != null ? allowingSnapshots : this.allowSnapshots;
         final ArtifactVersions artifactVersions = getHelper().lookupArtifactVersions( artifact, usePluginRepositories );
-        return artifactVersions.getNewestVersion( versionRange, null, null, includeSnapshots,
-                true, true, allowDowngrade );
+        return artifactVersions.getNewestVersion( versionRange, null, includeSnapshots, allowDowngrade );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.Restriction;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -173,7 +174,8 @@ public class UseLatestSnapshotsMojo
                     ArtifactVersion upperBound =
                             segment >= 0 ? versionComparator.incrementSegment( lowerBound, segment ) : null;
                     getLog().info( "Upper bound: " + ( upperBound == null ? "none" : upperBound.toString() ) );
-                    ArtifactVersion[] newer = versions.getVersions( lowerBound, upperBound, true, false, false );
+                    Restriction restriction = new Restriction( lowerBound, false, upperBound, false );
+                    ArtifactVersion[] newer = versions.getVersions( restriction, true );
                     getLog().debug( "Candidate versions " + Arrays.asList( newer ) );
 
                     String latestVersion;

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -30,6 +30,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.Restriction;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -155,7 +156,8 @@ public class UseNextSnapshotsMojo
                     ArtifactVersion upperBound =
                             segment >= 0 ? versionComparator.incrementSegment( lowerBound, segment ) : null;
                     getLog().info( "Upper bound: " + ( upperBound == null ? "none" : upperBound.toString() ) );
-                    ArtifactVersion[] newer = versions.getVersions( lowerBound, upperBound, true, false, false );
+                    Restriction restriction = new Restriction( lowerBound, false, upperBound, false );
+                    ArtifactVersion[] newer = versions.getVersions( restriction, true );
                     getLog().debug( "Candidate versions " + Arrays.asList( newer ) );
                     for ( ArtifactVersion artifactVersion : newer )
                     {

--- a/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -147,7 +147,7 @@ public abstract class AbstractVersionDetails
 
     private ArtifactVersion[] getNewerVersions( ArtifactVersion version, boolean includeSnapshots )
     {
-         Restriction restriction = new Restriction( version, false, null, false );
+        Restriction restriction = new Restriction( version, false, null, false );
         return getVersions( restriction, includeSnapshots );
     }
 
@@ -187,7 +187,7 @@ public abstract class AbstractVersionDetails
             {
                 continue;
             }
-            if ( restriction != null && !restriction.containsVersion( candidate ) )
+            if ( restriction != null && !isVersionInRestriction( restriction, candidate ) )
             {
                 continue;
             }
@@ -307,7 +307,7 @@ public abstract class AbstractVersionDetails
             {
                 continue;
             }
-            if ( restriction != null && !restriction.containsVersion( candidate ) )
+            if ( restriction != null && !isVersionInRestriction( restriction, candidate ) )
             {
                 continue;
             }
@@ -343,7 +343,7 @@ public abstract class AbstractVersionDetails
             {
                 continue;
             }
-            if ( restriction != null && !restriction.containsVersion( candidate ) )
+            if ( restriction != null && !isVersionInRestriction( restriction, candidate ) )
             {
                 continue;
             }
@@ -571,4 +571,33 @@ public abstract class AbstractVersionDetails
         }
         return of( newVersion.toString() );
     }
+
+    /**
+     * Checks if the candidate version is in the range of the restriction.
+     * a custom comparator is/can be used to have milestones and rcs before final releases,
+     * which is not yet possible with {@link Restriction#containsVersion(ArtifactVersion)}.
+     * @param restriction the range to check against.
+     * @param candidate the version to check.
+     * @return true if the candidate version is within the range of the restriction parameter.
+     */
+    private boolean isVersionInRestriction( Restriction restriction, ArtifactVersion candidate )
+    {
+        ArtifactVersion lowerBound = restriction.getLowerBound();
+        ArtifactVersion upperBound = restriction.getUpperBound();
+        boolean includeLower = restriction.isLowerBoundInclusive();
+        boolean includeUpper = restriction.isUpperBoundInclusive();
+        final VersionComparator versionComparator = getVersionComparator();
+        int lower = lowerBound == null ? -1 : versionComparator.compare( lowerBound, candidate );
+        int upper = upperBound == null ? +1 : versionComparator.compare( upperBound, candidate );
+        if ( lower > 0 || upper < 0 )
+        {
+            return false;
+        }
+        if ( ( !includeLower && lower == 0 ) || ( !includeUpper && upper == 0 ) )
+        {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/UpdateScope.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.Restriction;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 
@@ -54,11 +55,13 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 3
-                        ? null
-                        : versionDetails.getOldestVersion( currentVersion,
-                        versionComparator.incrementSegment( currentVersion, 2 ),
-                        includeSnapshots, false, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 3 )
+                {
+                    return null;
+                }
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 2 );
+                Restriction restriction = new Restriction( currentVersion, false, upperBound, false );
+                return versionDetails.getOldestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -73,11 +76,13 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 3
-                        ? null
-                        : versionDetails.getNewestVersion( currentVersion,
-                        versionComparator.incrementSegment( currentVersion, 2 ),
-                        includeSnapshots, false, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 3 )
+                {
+                    return null;
+                }
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 2 );
+                Restriction restriction = new Restriction( currentVersion, false, upperBound, false );
+                return versionDetails.getNewestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -92,10 +97,13 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                                : versionDetails.getVersions( currentVersion,
-                                                              versionComparator.incrementSegment( currentVersion, 2 ),
-                                                              includeSnapshots, false, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 3 )
+                {
+                    return null;
+                }
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 2 );
+                Restriction restriction = new Restriction( currentVersion, false, upperBound, false );
+                return versionDetails.getVersions( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -120,10 +128,14 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                        : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
-                        versionComparator.incrementSegment( currentVersion, 1 ),
-                        includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 3 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 2 );
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 1 );
+                Restriction restriction = new Restriction( lowerBound, true, upperBound, false );
+                return versionDetails.getOldestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -138,10 +150,14 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                        : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 2 ),
-                        versionComparator.incrementSegment( currentVersion, 1 ),
-                        includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 3 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 2 );
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 1 );
+                Restriction restriction = new Restriction( lowerBound, true, upperBound, false );
+                return versionDetails.getNewestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -156,10 +172,14 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 3 ? null
-                        : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 2 ),
-                                versionComparator.incrementSegment( currentVersion, 1 ), includeSnapshots, true,
-                                false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 3 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 2 );
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 1 );
+                Restriction restriction = new Restriction( lowerBound, true, upperBound, false );
+                return versionDetails.getVersions( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -184,10 +204,14 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
-                        : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
-                        versionComparator.incrementSegment( currentVersion, 0 ),
-                        includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 2 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 1 );
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 0 );
+                Restriction restriction = new Restriction( lowerBound, true, upperBound, false );
+                return versionDetails.getOldestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -202,10 +226,14 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
-                        : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 1 ),
-                                versionComparator.incrementSegment( currentVersion, 0 ), includeSnapshots, true,
-                                false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 2 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 1 );
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 0 );
+                Restriction restriction = new Restriction( lowerBound, true, upperBound, false );
+                return versionDetails.getNewestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -220,10 +248,14 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 2 ? null
-                        : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 1 ),
-                        versionComparator.incrementSegment( currentVersion, 0 ),
-                        includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 2 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 1 );
+                ArtifactVersion upperBound = versionComparator.incrementSegment( currentVersion, 0 );
+                Restriction restriction = new Restriction( lowerBound, true, upperBound, false );
+                return versionDetails.getVersions( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -248,9 +280,13 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
-                        : versionDetails.getOldestVersion( versionComparator.incrementSegment( currentVersion, 0 ),
-                                                                   null, includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 1 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 0 );
+                Restriction restriction = new Restriction( lowerBound, true, null, false );
+                return versionDetails.getOldestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -265,9 +301,13 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 1 ? null
-                        : versionDetails.getNewestVersion( versionComparator.incrementSegment( currentVersion, 0 ),
-                                                                   null, includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 1 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 0 );
+                Restriction restriction = new Restriction( lowerBound, true, null, false );
+                return versionDetails.getNewestVersion( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -282,10 +322,13 @@ public abstract class UpdateScope
             VersionComparator versionComparator = versionDetails.getVersionComparator();
             try
             {
-                return versionComparator.getSegmentCount( currentVersion ) < 1
-                        ? null
-                        : versionDetails.getVersions( versionComparator.incrementSegment( currentVersion, 0 ),
-                        null, includeSnapshots, true, false );
+                if ( versionComparator.getSegmentCount( currentVersion ) < 1 )
+                {
+                    return null;
+                }
+                ArtifactVersion lowerBound = versionComparator.incrementSegment( currentVersion, 0 );
+                Restriction restriction = new Restriction( lowerBound, true, null, false );
+                return versionDetails.getVersions( restriction, includeSnapshots );
             }
             catch ( InvalidSegmentException e )
             {
@@ -306,21 +349,24 @@ public abstract class UpdateScope
         public ArtifactVersion getOldestUpdate( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                 boolean includeSnapshots )
         {
-            return versionDetails.getOldestVersion( currentVersion, null, includeSnapshots, false, false );
+            Restriction restriction = new Restriction( currentVersion, false, null, false );
+            return versionDetails.getOldestVersion( restriction, includeSnapshots );
         }
 
         /** {@inheritDoc} */
         public ArtifactVersion getNewestUpdate( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                 boolean includeSnapshots )
         {
-            return versionDetails.getNewestVersion( currentVersion, null, includeSnapshots, false, false );
+            Restriction restriction = new Restriction( currentVersion, false, null, false );
+            return versionDetails.getNewestVersion( restriction, includeSnapshots );
         }
 
         /** {@inheritDoc} */
         public ArtifactVersion[] getAllUpdates( VersionDetails versionDetails, ArtifactVersion currentVersion,
                                                 boolean includeSnapshots )
         {
-            return versionDetails.getVersions( currentVersion, null, includeSnapshots, false, false );
+            Restriction restriction = new Restriction( currentVersion, false, null, false );
+            return versionDetails.getVersions( restriction, includeSnapshots );
         }
 
     };

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -20,6 +20,7 @@ package org.codehaus.mojo.versions.api;
  */
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.Restriction;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
@@ -100,32 +101,24 @@ public interface VersionDetails
     /**
      * Returns all available versions within the specified bounds.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param restriction version criteria.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true</code> if the upper bound is inclusive.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
-    ArtifactVersion[] getVersions( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
-                                   boolean includeLower, boolean includeUpper );
+    ArtifactVersion[] getVersions( Restriction restriction, boolean includeSnapshots );
 
     /**
      * Returns all available versions within the specified bounds.
      *
      * @param versionRange The version range within which the version must exist where <code>null</code> imples
      *            <code>[,)</code>.
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param restriction version criteria.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true</code> if the upper bound is inclusive.
      * @return all available versions within the specified version range.
      * @since 1.0-beta-1
      */
-    ArtifactVersion[] getVersions( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
-                                   boolean includeSnapshots, boolean includeLower, boolean includeUpper );
+    ArtifactVersion[] getVersions( VersionRange versionRange, Restriction restriction, boolean includeSnapshots );
 
     /**
      * Returns the latest version newer than the specified lowerBound, but less than the specified upper bound or
@@ -155,16 +148,12 @@ public interface VersionDetails
      * Returns the latest version newer than the specified current version, but less than the specified upper bound or
      * <code>null</code> if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param restriction version criteria.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true</code> if the upper bound is inclusive.
      * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-alpha-3
      */
-    ArtifactVersion getNewestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
-                                      boolean includeLower, boolean includeUpper );
+    ArtifactVersion getNewestVersion( Restriction restriction, boolean includeSnapshots );
 
     /**
      * Returns the latest version newer than the specified current version, but less than the specified upper bound or
@@ -172,16 +161,12 @@ public interface VersionDetails
      *
      * @param versionRange The version range within which the version must exist where <code>null</code> imples
      *            <code>[,)</code>.
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param restriction version criteria.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true</code> if the upper bound is inclusive.
      * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-alpha-3
      */
-    ArtifactVersion getNewestVersion( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
-                                      boolean includeSnapshots, boolean includeLower, boolean includeUpper );
+    ArtifactVersion getNewestVersion( VersionRange versionRange, Restriction restriction, boolean includeSnapshots );
 
     /**
      * Returns the latest version within the specified version range or <code>null</code> if no such version exists.
@@ -230,32 +215,24 @@ public interface VersionDetails
     /**
      * Returns the oldest version within the specified bounds or <code>null</code> if no such version exists.
      *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param restriction version criteria.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true</code> if the upper bound is inclusive.
      * @return the oldest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getOldestVersion( ArtifactVersion lowerBound, ArtifactVersion upperBound, boolean includeSnapshots,
-                                      boolean includeLower, boolean includeUpper );
+    ArtifactVersion getOldestVersion( Restriction restriction, boolean includeSnapshots );
 
     /**
      * Returns the oldest version within the specified bounds or <code>null</code> if no such version exists.
      *
      * @param versionRange The version range within which the version must exist where <code>null</code> imples
      *            <code>[,)</code>.
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
+     * @param restriction version criteria.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
-     * @param includeLower <code>true</code> if the lower bound is inclusive.
-     * @param includeUpper <code>true</code> if the upper bound is inclusive.
      * @return the oldest version between lowerBound and upperBound or <code>null</code> if no version is available.
      * @since 1.0-beta-1
      */
-    ArtifactVersion getOldestVersion( VersionRange versionRange, ArtifactVersion lowerBound, ArtifactVersion upperBound,
-                                      boolean includeSnapshots, boolean includeLower, boolean includeUpper );
+    ArtifactVersion getOldestVersion( VersionRange versionRange, Restriction restriction, boolean includeSnapshots );
 
     /**
      * Returns the oldest version newer than the specified current version, but within the the specified update scope or


### PR DESCRIPTION
i have a PR waiting to be pushed/suggested but i need these methods to be refactored first so i dont fall into more than 7 parameters compiler errors + the new design i suggest makes the methods more easy to maintain.

i know this does not add any more features but i hope this can be usefull for the quality and ease of maintenance there after.

the basics are sending a Restriction parameter instead of 4 (lower/upper bound and accept booleans), thus gaining 3 more free params to send for other features (next PR to filter RCs is waiting for this one to be accepted)

Thank you for your time