### PR TITLE
Issue 342 scm set tag add new elements

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
@@ -93,33 +93,39 @@ public class SetScmTagMojo extends AbstractVersionsUpdaterMojo
             List<String> failures = new ArrayList<>();
             if ( !isBlank( newTag ) )
             {
-                getLog().info( "Updating tag: " + scm.getTag() + " -> " + newTag );
-                if ( !PomHelper.setProjectValue( pom, "/project/scm/tag", newTag ) )
+                getLog().info( "Updating tag: " + ( scm != null && scm.getTag() != null
+                        ? scm.getTag() : "(empty)" ) + " -> " + newTag );
+                if ( !PomHelper.setElementValue( pom, "/project/scm", "tag", newTag ) )
                 {
                     failures.add( "tag: " + newTag );
                 }
             }
             if ( !isBlank( connection ) )
             {
-                getLog().info( "Updating connection: " + scm.getConnection() + " -> " + connection );
-                if ( !PomHelper.setProjectValue( pom, "/project/scm/connection", connection ) )
+                getLog().info( "Updating connection: " + ( scm != null && scm.getConnection() != null
+                        ? scm.getConnection() : "(empty)" ) + " -> " + connection );
+                if ( !PomHelper.setElementValue( pom, "/project/scm", "connection", connection ) )
                 {
                     failures.add( "connection: " + connection );
                 }
             }
             if ( !isBlank( developerConnection ) )
             {
-                getLog().info( "Updating developerConnection: " + scm.getDeveloperConnection() + " -> "
+                getLog().info( "Updating developerConnection: "
+                        + ( scm != null && scm.getDeveloperConnection() != null
+                        ? scm.getDeveloperConnection() : "(empty)" ) + " -> "
                         + developerConnection );
-                if ( !PomHelper.setProjectValue( pom, "/project/scm/developerConnection", developerConnection ) )
+                if ( !PomHelper.setElementValue( pom, "/project/scm", "developerConnection",
+                        developerConnection ) )
                 {
                     failures.add( "developerConnection: " + developerConnection );
                 }
             }
             if ( !isBlank( url ) )
             {
-                getLog().info( "Updating url: " + scm.getUrl() + " -> " + url );
-                if ( !PomHelper.setProjectValue( pom, "/project/scm/url", url ) )
+                getLog().info( "Updating url: " + ( scm != null && scm.getUrl() != null
+                        ? scm.getUrl() : "(empty)" ) + " -> " + url );
+                if ( !PomHelper.setElementValue( pom, "/project/scm", "url", url ) )
                 {
                     failures.add( "url: " + url );
                 }

--- a/src/test/java/org/codehaus/mojo/versions/SetScmTagMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/SetScmTagMojoTest.java
@@ -1,0 +1,57 @@
+package org.codehaus.mojo.versions;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.codehaus.mojo.versions.utils.BaseMojoTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.matchesPattern;
+
+/**
+ * Basic tests for {@linkplain SetPropertyMojoTest}.
+ *
+ * @author Andrzej Jarmoniuk
+ */
+public class SetScmTagMojoTest extends BaseMojoTestCase
+{
+    @Test
+    public void testNewScmValues() throws Exception
+    {
+        Path pomFile = Paths.get( "target/test-classes/org/codehaus/mojo/set-scm-tag/issue-342-pom.xml" );
+        createMojo( "set-scm-tag", pomFile.toString() )
+                .execute();
+        String output = String.join( "", Files.readAllLines( pomFile ) )
+                .replaceAll( "\\s*", "" );
+        assertThat( output, allOf(
+                        matchesPattern( ".*<scm>.*<tag>\\s*newTag\\s*</tag>.*</scm>.*" ),
+                        matchesPattern( ".*<scm>.*<url>\\s*url\\s*</url>.*</scm>.*" ),
+                        matchesPattern( ".*<scm>.*<connection>\\s*connection\\s*</connection>.*</scm>.*" ),
+                        matchesPattern( ".*<scm>.*<developerConnection>\\s*"
+                                + "developerConnection\\s*</developerConnection>.*</scm>.*" )
+                )
+        );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/versions/utils/ModifiedPomXMLEventReaderUtils.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/ModifiedPomXMLEventReaderUtils.java
@@ -1,0 +1,62 @@
+package org.codehaus.mojo.versions.utils;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * <p>Utilities for the {@link ModifiedPomXMLEventReader} class</p>
+ *
+ * @author Andrzej Jarmoniuk
+ */
+public class ModifiedPomXMLEventReaderUtils
+{
+    public static <P extends ModifiedPomXMLEventReader> Matcher<P> matches( String pattern )
+    {
+        return new TypeSafeMatcher<P>()
+        {
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( pattern );
+            }
+
+            @Override
+            protected void describeMismatchSafely( P pom, Description description )
+            {
+                description.appendText( asString( pom ) );
+            }
+
+            @Override
+            protected boolean matchesSafely( P pom )
+            {
+                return pattern.matches( asString( pom ) );
+            }
+
+            private String asString( P pom )
+            {
+                return pom.asStringBuilder().toString().replaceAll( "\\s", "" );
+            }
+        };
+    }
+}

--- a/src/test/resources/org/codehaus/mojo/set-scm-tag/issue-342-pom.xml
+++ b/src/test/resources/org/codehaus/mojo/set-scm-tag/issue-342-pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <scm/>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <newTag>newTag</newTag>
+                    <connection>connection</connection>
+                    <developerConnection>developerConnection</developerConnection>
+                    <url>url</url>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/org/codehaus/mojo/set-scm-tag/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/set-scm-tag/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <scm/>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <newTag>newTag</newTag>
+                    <connection>connection</connection>
+                    <developerConnection>developerConnection</developerConnection>
+                    <url>url</url>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This is some enhancement of the scm-tag functionality. Whereas it was only possible to add new values to the existing scm subelements, this enhancement adds the possibility to add missing elements as well.

In the code, I've replaced stack usage with reflection in PomHelper, but it doesn't really make a difference (can revert it if necessary, I think it's a question of taste). Plus, encapsulated some implementation details, recursion state (drawback of using recursion), and helper methods within a local class.

It's not fully flexible -- it doesn't allow us to create new elements if also the parent element is missing -- but since it's not XSD-aware, it wouldn't know where to put the new element :)