### PR TITLE
#697: Migrate to JSR330

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -19,6 +19,8 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,12 +28,17 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.apache.maven.shared.artifact.filter.PatternIncludesArtifactFilter;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
@@ -136,6 +143,16 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
      */
     @Parameter( property = "excludeReactor", defaultValue = "true" )
     private boolean excludeReactor;
+
+    @Inject
+    protected AbstractVersionsDependencyUpdaterMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * Should the project/dependencies section of the pom be processed.

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDisplayMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDisplayMojo.java
@@ -19,6 +19,8 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,7 +29,12 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 
 /**
  * Abstract base class for the Display___ mojos.
@@ -75,6 +82,16 @@ public abstract class AbstractVersionsDisplayMojo
     protected int outputLineWidth;
 
     private boolean outputFileError = false;
+
+    @Inject
+    protected AbstractVersionsDisplayMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     protected void logInit()
     {

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -19,6 +19,8 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
@@ -37,7 +39,6 @@ import org.apache.maven.doxia.siterenderer.Renderer;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
@@ -64,17 +65,9 @@ public abstract class AbstractVersionsReport
      *
      * @since 1.0-alpha-3
      */
-    @Component
     protected I18N i18n;
 
-    @Component
     protected RepositorySystem repositorySystem;
-
-    /**
-     * @since 1.0-alpha-3
-     */
-    @Component
-    private ArtifactResolver resolver;
 
     /**
      * Skip entire check.
@@ -89,7 +82,6 @@ public abstract class AbstractVersionsReport
      *
      * @since 1.0-alpha-1
      */
-    @Component
     protected ArtifactMetadataSource artifactMetadataSource;
 
     /**
@@ -107,7 +99,6 @@ public abstract class AbstractVersionsReport
     /**
      * @since 1.0-alpha-3
      */
-    @Component
     private WagonManager wagonManager;
 
     /**
@@ -168,7 +159,6 @@ public abstract class AbstractVersionsReport
     @Parameter( defaultValue = "${mojoExecution}", required = true, readonly = true )
     private MojoExecution mojoExecution;
 
-    @Component
     protected ArtifactResolver artifactResolver;
 
     /**
@@ -199,6 +189,17 @@ public abstract class AbstractVersionsReport
     protected Set<String> ignoredVersions;
 
     // --------------------- GETTER / SETTER METHODS ---------------------
+
+    @Inject
+    protected AbstractVersionsReport( I18N i18n, RepositorySystem repositorySystem, ArtifactResolver artifactResolver,
+                                   ArtifactMetadataSource artifactMetadataSource, WagonManager wagonManager )
+    {
+        this.i18n = i18n;
+        this.repositorySystem = repositorySystem;
+        this.artifactResolver = artifactResolver;
+        this.artifactMetadataSource = artifactMetadataSource;
+        this.wagonManager = wagonManager;
+    }
 
     public VersionsHelper getHelper()
         throws MavenReportException
@@ -357,11 +358,6 @@ public abstract class AbstractVersionsReport
     public String getComparisonMethod()
     {
         return comparisonMethod;
-    }
-
-    public ArtifactResolver getResolver()
-    {
-        return resolver;
     }
 
     public I18N getI18n()

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 
@@ -45,7 +46,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
@@ -86,19 +86,11 @@ public abstract class AbstractVersionsUpdaterMojo
     @Parameter( defaultValue = "${project}", required = true, readonly = true )
     protected MavenProject project;
 
-    @Component
     protected RepositorySystem repositorySystem;
 
     /**
      * @since 1.0-alpha-1
      */
-    @Component
-    protected org.apache.maven.artifact.resolver.ArtifactResolver resolver;
-
-    /**
-     * @since 1.0-alpha-1
-     */
-    @Component
     protected MavenProjectBuilder projectBuilder;
 
     /**
@@ -112,7 +104,6 @@ public abstract class AbstractVersionsUpdaterMojo
      *
      * @since 1.0-alpha-1
      */
-    @Component
     protected ArtifactMetadataSource artifactMetadataSource;
 
     /**
@@ -136,7 +127,6 @@ public abstract class AbstractVersionsUpdaterMojo
     /**
      * @since 1.0-alpha-3
      */
-    @Component
     private WagonManager wagonManager;
 
     /**
@@ -195,7 +185,6 @@ public abstract class AbstractVersionsUpdaterMojo
     @Parameter( defaultValue = "${mojoExecution}", required = true, readonly = true )
     private MojoExecution mojoExecution;
 
-    @Component
     protected ArtifactResolver artifactResolver;
     /**
      * The format used to record changes. If "none" is specified, no changes are recorded.
@@ -246,6 +235,20 @@ public abstract class AbstractVersionsUpdaterMojo
     protected Set<String> ignoredVersions;
 
     // --------------------- GETTER / SETTER METHODS ---------------------
+
+    @Inject
+    protected AbstractVersionsUpdaterMojo( RepositorySystem repositorySystem,
+                                          MavenProjectBuilder projectBuilder,
+                                          ArtifactMetadataSource artifactMetadataSource,
+                                          WagonManager wagonManager,
+                                          ArtifactResolver artifactResolver )
+    {
+        this.repositorySystem = repositorySystem;
+        this.projectBuilder = projectBuilder;
+        this.artifactMetadataSource = artifactMetadataSource;
+        this.wagonManager = wagonManager;
+        this.artifactResolver = artifactResolver;
+    }
 
     public VersionsHelper getHelper() throws MojoExecutionException
     {
@@ -526,7 +529,7 @@ public abstract class AbstractVersionsUpdaterMojo
         artifact.setVersion( updateVersion.toString() );
         try
         {
-            resolver.resolveAlways( artifact, remoteArtifactRepositories, localRepository );
+            artifactResolver.resolveAlways( artifact, remoteArtifactRepositories, localRepository );
         }
         catch ( ArtifactResolutionException e )
         {

--- a/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.io.File;
@@ -31,15 +32,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
@@ -112,10 +116,21 @@ public class CompareDependenciesMojo
     /**
      * The project builder used to initialize the remote project.
      */
-    @Component
     protected MavenProjectBuilder mavenProjectBuilder;
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public CompareDependenciesMojo( RepositorySystem repositorySystem,
+                                    MavenProjectBuilder projectBuilder,
+                                    ArtifactMetadataSource artifactMetadataSource,
+                                    WagonManager wagonManager,
+                                    ArtifactResolver artifactResolver,
+                                    MavenProjectBuilder mavenProjectBuilder )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+        this.mavenProjectBuilder = mavenProjectBuilder;
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
@@ -19,21 +19,28 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
+import org.codehaus.plexus.i18n.I18N;
 
 import static java.util.Collections.EMPTY_MAP;
 import static org.codehaus.mojo.versions.utils.MiscUtils.filter;
@@ -92,6 +99,13 @@ public class DependencyUpdatesReport extends AbstractVersionsReport
      */
     @Parameter( property = "onlyUpgradable", defaultValue = "false" )
     protected boolean onlyUpgradable;
+
+    @Inject
+    protected DependencyUpdatesReport( I18N i18n, RepositorySystem repositorySystem, ArtifactResolver artifactResolver,
+                                       ArtifactMetadataSource artifactMetadataSource, WagonManager wagonManager )
+    {
+        super( i18n, repositorySystem, artifactResolver, artifactMetadataSource, wagonManager );
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.ArrayList;
@@ -31,7 +32,10 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
@@ -42,6 +46,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.UpdateScope;
 import org.codehaus.mojo.versions.filtering.DependencyFilter;
@@ -332,6 +338,16 @@ public class DisplayDependencyUpdatesMojo
     private List<String> pluginManagementDependencyExcludes;
 
     // --------------------- GETTER / SETTER METHODS ---------------------
+
+    @Inject
+    public DisplayDependencyUpdatesMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     private static Set<Dependency> extractPluginDependenciesFromPluginsInPluginManagement( Build build )
     {

--- a/src/main/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojo.java
@@ -19,16 +19,22 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 
@@ -44,6 +50,16 @@ public class DisplayParentUpdatesMojo
 {
 
     public static final int MESSAGE_LENGTH = 68;
+
+    @Inject
+    public DisplayParentUpdatesMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     @Override
     public void execute()

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
@@ -48,10 +49,13 @@ import java.util.regex.Pattern;
 import org.apache.maven.BuildFailureException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
@@ -81,11 +85,12 @@ import org.apache.maven.plugin.PluginNotFoundException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.version.PluginVersionNotFoundException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.DefaultProjectBuilderConfiguration;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Settings;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
@@ -135,13 +140,11 @@ public class DisplayPluginUpdatesMojo
     /**
      * @since 1.0-alpha-1
      */
-    @Component
     private LifecycleExecutor lifecycleExecutor;
 
     /**
      * @since 1.0-alpha-3
      */
-    @Component
     private ModelInterpolator modelInterpolator;
 
     /**
@@ -149,16 +152,33 @@ public class DisplayPluginUpdatesMojo
      *
      * @since 1.0-alpha-1
      */
-    @Component
     private PluginManager pluginManager;
 
     /**
      * @since 1.3
      */
-    @Component
     private RuntimeInformation runtimeInformation;
 
     // --------------------- GETTER / SETTER METHODS ---------------------
+
+    @Inject
+    @SuppressWarnings( "checkstyle:ParameterNumber" )
+    public DisplayPluginUpdatesMojo( RepositorySystem repositorySystem,
+                                     MavenProjectBuilder projectBuilder,
+                                     ArtifactMetadataSource artifactMetadataSource,
+                                     WagonManager wagonManager,
+                                     ArtifactResolver artifactResolver,
+                                     LifecycleExecutor lifecycleExecutor,
+                                     ModelInterpolator modelInterpolator,
+                                     PluginManager pluginManager,
+                                     RuntimeInformation runtimeInformation )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+        this.lifecycleExecutor = lifecycleExecutor;
+        this.modelInterpolator = modelInterpolator;
+        this.pluginManager = pluginManager;
+        this.runtimeInformation = runtimeInformation;
+    }
 
     /**
      * Returns the pluginManagement section of the super-pom.

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.ArrayList;
@@ -26,13 +27,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -117,6 +123,16 @@ public class DisplayPropertyUpdatesMojo
     // -------------------------- STATIC METHODS --------------------------
 
     // -------------------------- OTHER METHODS --------------------------
+
+    @Inject
+    public DisplayPropertyUpdatesMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     public void execute()
         throws MojoExecutionException, MojoFailureException

--- a/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
@@ -26,12 +27,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -55,6 +61,16 @@ public class ForceReleasesMojo
     private final Pattern matchSnapshotRegex = Pattern.compile( "^(.+)-((SNAPSHOT)|(\\d{8}\\.\\d{6}-\\d+))$" );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public ForceReleasesMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
@@ -26,11 +27,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -56,6 +62,16 @@ public class LockSnapshotsMojo
     private final Pattern matchSnapshotRegex = Pattern.compile( "-" + Artifact.SNAPSHOT_VERSION );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public LockSnapshotsMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.
@@ -167,7 +183,7 @@ public class LockSnapshotsMojo
 
         try
         {
-            resolver.resolve( artifact, getProject().getRemoteArtifactRepositories(), localRepository );
+            artifactResolver.resolve( artifact, getProject().getRemoteArtifactRepositories(), localRepository );
 
             lockedVersion = artifact.getVersion();
         }
@@ -193,7 +209,7 @@ public class LockSnapshotsMojo
         try
         {
             Artifact depArtifact = getHelper().createDependencyArtifact( dep );
-            resolver.resolve( depArtifact, getProject().getRemoteArtifactRepositories(), localRepository );
+            artifactResolver.resolve( depArtifact, getProject().getRemoteArtifactRepositories(), localRepository );
 
             lockedVersion = depArtifact.getVersion();
         }

--- a/src/main/java/org/codehaus/mojo/versions/PluginUpdatesReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/PluginUpdatesReport.java
@@ -19,20 +19,27 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.utils.PluginComparator;
+import org.codehaus.plexus.i18n.I18N;
 
 import static org.codehaus.mojo.versions.utils.MiscUtils.filter;
 
@@ -69,6 +76,13 @@ public class PluginUpdatesReport extends AbstractVersionsReport
      */
     @Parameter( property = "onlyUpgradable", defaultValue = "false" )
     protected boolean onlyUpgradable;
+
+    @Inject
+    protected PluginUpdatesReport( I18N i18n, RepositorySystem repositorySystem, ArtifactResolver artifactResolver,
+                                       ArtifactMetadataSource artifactMetadataSource, WagonManager wagonManager )
+    {
+        super( i18n, repositorySystem, artifactResolver, artifactMetadataSource, wagonManager );
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/codehaus/mojo/versions/PropertyUpdatesReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/PropertyUpdatesReport.java
@@ -19,18 +19,25 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.utils.PropertyComparator;
+import org.codehaus.plexus.i18n.I18N;
 
 /**
  * Generates a report of available updates for properties of a project which are linked to the dependencies and/or
@@ -76,6 +83,13 @@ public class PropertyUpdatesReport
      */
     @Parameter( property = "autoLinkItems", defaultValue = "true" )
     private boolean autoLinkItems;
+
+    @Inject
+    protected PropertyUpdatesReport( I18N i18n, RepositorySystem repositorySystem, ArtifactResolver artifactResolver,
+                                      ArtifactMetadataSource artifactMetadataSource, WagonManager wagonManager )
+    {
+        super( i18n, repositorySystem, artifactResolver, artifactMetadataSource, wagonManager );
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
@@ -28,7 +29,10 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.model.Dependency;
@@ -36,6 +40,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -109,6 +115,16 @@ public class ResolveRangesMojo
     private final Pattern matchRangeRegex = Pattern.compile( "," );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public ResolveRangesMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.io.File;
@@ -39,14 +40,18 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.change.VersionChange;
 import org.codehaus.mojo.versions.change.VersionChanger;
@@ -162,10 +167,7 @@ public class SetMojo extends AbstractVersionsUpdaterMojo
 
     /**
      * Component used to prompt for input
-     *
-     * @component
      */
-    @Component
     private Prompter prompter;
 
     /**
@@ -239,6 +241,18 @@ public class SetMojo extends AbstractVersionsUpdaterMojo
      * The changes to module coordinates. Guarded by this.
      */
     private final transient List<VersionChange> sourceChanges = new ArrayList<>();
+
+    @Inject
+    public SetMojo( RepositorySystem repositorySystem,
+                       MavenProjectBuilder projectBuilder,
+                       ArtifactMetadataSource artifactMetadataSource,
+                       WagonManager wagonManager,
+                       ArtifactResolver artifactResolver,
+                       Prompter prompter )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+        this.prompter = prompter;
+    }
 
     private synchronized void addChange( String groupId, String artifactId, String oldVersion, String newVersion )
     {

--- a/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -19,16 +19,22 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -81,6 +87,16 @@ public class SetPropertyMojo
 
     @Parameter( property = "propertiesVersionsFile" )
     private String propertiesVersionsFile;
+
+    @Inject
+    public SetPropertyMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
@@ -1,17 +1,23 @@
 package org.codehaus.mojo.versions;
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Scm;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -59,6 +65,16 @@ public class SetScmTagMojo extends AbstractVersionsUpdaterMojo
      */
     @Parameter( property = "url" )
     private String url;
+
+    @Inject
+    public SetScmTagMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * Called when this mojo is executed.

--- a/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.List;
@@ -26,11 +27,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -58,6 +64,16 @@ public class UnlockSnapshotsMojo extends AbstractVersionsDependencyUpdaterMojo
     private final Pattern matchSnapshotRegex = Pattern.compile( "-(\\d{8}\\.\\d{6})-(\\d+)$" );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UnlockSnapshotsMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UpdateChildModulesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdateChildModulesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.io.File;
@@ -28,11 +29,16 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -62,6 +68,16 @@ public class UpdateChildModulesMojo
      * The version that we are updating to. Guarded by this.
      */
     private transient String sourceVersion = null;
+
+    @Inject
+    public UpdateChildModulesMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * Called when this mojo is executed.

--- a/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
@@ -19,10 +19,14 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
@@ -31,6 +35,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
@@ -93,6 +99,16 @@ public class UpdateParentMojo extends AbstractVersionsUpdaterMojo
     protected boolean allowDowngrade;
 
     // -------------------------- OTHER METHODS --------------------------
+
+    @Inject
+    public UpdateParentMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
@@ -19,16 +19,22 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Map;
 
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -122,6 +128,16 @@ public class UpdatePropertiesMojo extends AbstractVersionsDependencyUpdaterMojo
     // -------------------------- STATIC METHODS --------------------------
 
     // -------------------------- OTHER METHODS --------------------------
+
+    @Inject
+    public UpdatePropertiesMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -19,16 +19,22 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Map;
 
+import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -119,6 +125,16 @@ public class UpdatePropertyMojo
     // -------------------------- STATIC METHODS --------------------------
 
     // -------------------------- OTHER METHODS --------------------------
+
+    @Inject
+    public UpdatePropertyMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -19,17 +19,23 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -62,6 +68,16 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo
     @Parameter( property = "forceVersion",
                 defaultValue = "false" )
     protected boolean forceVersion;
+
+    @Inject
+    public UseDepVersionMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     @Override
     protected void update( ModifiedPomXMLEventReader pom )

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.ArrayList;
@@ -30,7 +31,10 @@ import java.util.regex.Pattern;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -39,6 +43,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -91,6 +97,16 @@ public class UseLatestReleasesMojo
     protected boolean allowIncrementalUpdates;
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseLatestReleasesMojo( RepositorySystem repositorySystem,
+                                     MavenProjectBuilder projectBuilder,
+                                     ArtifactMetadataSource artifactMetadataSource,
+                                     WagonManager wagonManager,
+                                     ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.ArrayList;
@@ -28,7 +29,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.Restriction;
@@ -37,6 +41,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -90,6 +96,16 @@ public class UseLatestSnapshotsMojo
     private final Pattern matchSnapshotRegex = Pattern.compile( "^(.+)-((SNAPSHOT)|(\\d{8}\\.\\d{6}-\\d+))$" );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseLatestSnapshotsMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -19,13 +19,17 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.io.IOException;
 import java.util.Collection;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
@@ -34,6 +38,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -90,6 +96,15 @@ public class UseLatestVersionsMojo
 
     // ------------------------------ METHODS --------------------------
 
+    @Inject
+    public UseLatestVersionsMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
@@ -26,12 +27,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -55,6 +61,16 @@ public class UseNextReleasesMojo
     private static final Pattern MATCH_SNAPSHOT_REGEX = Pattern.compile( "^(.+)-((SNAPSHOT)|(\\d{8}\\.\\d{6}-\\d+))$" );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseNextReleasesMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Arrays;
@@ -27,7 +28,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.Restriction;
@@ -36,6 +40,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
@@ -85,6 +91,16 @@ public class UseNextSnapshotsMojo
     private final Pattern matchSnapshotRegex = Pattern.compile( "^(.+)-((SNAPSHOT)|(\\d{8}\\.\\d{6}-\\d+))$" );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseNextSnapshotsMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseNextVersionsMojo.java
@@ -19,17 +19,23 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -46,6 +52,16 @@ public class UseNextVersionsMojo
 {
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseNextVersionsMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
@@ -19,18 +19,24 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -46,6 +52,16 @@ public class UseReactorMojo
 {
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseReactorMojo( RepositorySystem repositorySystem,
+                                MavenProjectBuilder projectBuilder,
+                                ArtifactMetadataSource artifactMetadataSource,
+                                WagonManager wagonManager,
+                                ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import java.util.Collection;
@@ -27,7 +28,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -35,6 +39,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -75,6 +81,16 @@ public class UseReleasesMojo
     private final Pattern matchSnapshotRegex = Pattern.compile( "^(.+)-((SNAPSHOT)|(\\d{8}\\.\\d{6}-\\d+))$" );
 
     // ------------------------------ METHODS --------------------------
+
+    @Inject
+    public UseReleasesMojo( RepositorySystem repositorySystem,
+                                           MavenProjectBuilder projectBuilder,
+                                           ArtifactMetadataSource artifactMetadataSource,
+                                           WagonManager wagonManager,
+                                           ArtifactResolver artifactResolver )
+    {
+        super( repositorySystem, projectBuilder, artifactMetadataSource, wagonManager, artifactResolver );
+    }
 
     /**
      * @param pom the pom to update.

--- a/src/test/java/org/codehaus/mojo/versions/PluginUpdatesReportTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/PluginUpdatesReportTest.java
@@ -27,12 +27,9 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.doxia.module.xhtml5.Xhtml5SinkFactory;
 import org.apache.maven.doxia.sink.SinkFactory;
-import org.apache.maven.doxia.tools.SiteTool;
-import org.apache.maven.doxia.tools.SiteToolException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
@@ -40,11 +37,12 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.model.RuleSet;
-import org.codehaus.plexus.i18n.I18N;
+import org.codehaus.mojo.versions.utils.MockUtils;
 import org.junit.Test;
 
 import static org.apache.maven.artifact.Artifact.SCOPE_RUNTIME;
 import static org.codehaus.mojo.versions.utils.MockUtils.mockArtifactMetadataSource;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockI18N;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
@@ -52,7 +50,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -67,7 +64,8 @@ public class PluginUpdatesReportTest
     {
         TestPluginUpdatesReport()
         {
-            mockPlexusComponents();
+            super( mockI18N(), mockRepositorySystem(), null, mockArtifactMetadataSource(), null );
+            siteTool = MockUtils.mockSiteTool();
 
             project = new MavenProject();
             project.setBuild( new Build() );
@@ -114,22 +112,9 @@ public class PluginUpdatesReportTest
             return this;
         }
 
-        /**
-         * <p></p>Mocks some Plexus components to speed up test execution.</p>
-         * <p>Note: these components could just as well be injected using
-         * <code>org.codehaus.plexus.PlexusTestCase.lookup</code>,
-         * but that method greatly slows down test execution.</p>
-         *
-         * @see <a href="https://codehaus-plexus.github.io/guides/developer-guide/building-components/component-testing.html">
-         * Testing Plexus Components</a>
-         */
-        private void mockPlexusComponents()
+        private static RepositorySystem mockRepositorySystem()
         {
-            i18n = mock( I18N.class );
-            when( i18n.getString( anyString(), any(), anyString() ) ).thenAnswer(
-                invocation -> invocation.getArgument( 2 ) );
-
-            repositorySystem = mock( RepositorySystem.class );
+            RepositorySystem repositorySystem = mock( RepositorySystem.class );
             when( repositorySystem.createPluginArtifact( any( Plugin.class ) ) ).thenAnswer(
                 invocation ->
                 {
@@ -137,18 +122,7 @@ public class PluginUpdatesReportTest
                     return new DefaultArtifact( plugin.getGroupId(), plugin.getArtifactId(), plugin.getVersion(),
                                                 SCOPE_RUNTIME, "maven-plugin", "jar", null );
                 } );
-
-            Artifact skinArtifact = mock( Artifact.class );
-            when( skinArtifact.getId() ).thenReturn( "" );
-            siteTool = mock( SiteTool.class );
-            try
-            {
-                when( siteTool.getSkinArtifactFromRepository( any(), any(), any() ) ).thenReturn( skinArtifact );
-            }
-            catch ( SiteToolException e )
-            {
-                throw new RuntimeException( e );
-            }
+            return repositorySystem;
         }
     }
 

--- a/src/test/java/org/codehaus/mojo/versions/SeparatePatternsForIncludesAnExcludesTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/SeparatePatternsForIncludesAnExcludesTest.java
@@ -21,7 +21,7 @@ public class SeparatePatternsForIncludesAnExcludesTest
     public void setUp()
         throws Exception
     {
-        mojo = new AbstractVersionsDependencyUpdaterMojo()
+        mojo = new AbstractVersionsDependencyUpdaterMojo( null, null, null, null, null )
         {
             protected void update( ModifiedPomXMLEventReader pom )
                 throws MojoExecutionException, MojoFailureException, XMLStreamException

--- a/src/test/java/org/codehaus/mojo/versions/SetMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/SetMojoTest.java
@@ -16,7 +16,7 @@ public class SetMojoTest extends BaseMojoTestCase
     @Test
     public void testGetIncrementedVersion() throws MojoExecutionException
     {
-        new SetMojo()
+        new SetMojo( null, null, null, null, null, null )
         {
             {
                 assertThat( getIncrementedVersion( "1.0.0", null ), is( "1.0.1-SNAPSHOT" ) );
@@ -31,7 +31,7 @@ public class SetMojoTest extends BaseMojoTestCase
     @Test
     public void testNextSnapshotIndexLowerBound()
     {
-        new SetMojo()
+        new SetMojo( null, null, null, null, null, null )
         {
             {
                 try
@@ -51,7 +51,7 @@ public class SetMojoTest extends BaseMojoTestCase
     @Test
     public void testNextSnapshotIndexUpperBound()
     {
-        new SetMojo()
+        new SetMojo( null, null, null, null, null, null )
         {
             {
                 try
@@ -73,7 +73,7 @@ public class SetMojoTest extends BaseMojoTestCase
     {
         try
         {
-            new SetMojo()
+            new SetMojo( null, null, null, null, null, null )
             {
                 {
                     project = new MavenProject();

--- a/src/test/java/org/codehaus/mojo/versions/UpdateParentMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/UpdateParentMojoTest.java
@@ -70,14 +70,14 @@ public class UpdateParentMojoTest
         changeRecorder = new TestChangeRecorder();
         artifactResolver = mock( ArtifactResolver.class );
 
-        mojo = new UpdateParentMojo()
+        mojo = new UpdateParentMojo( repositorySystem,
+                null,
+                artifactMetadataSource,
+                null,
+                artifactResolver )
         {{
             setProject( createProject() );
             reactorProjects = Collections.emptyList();
-            repositorySystem = UpdateParentMojoTest.repositorySystem;
-            artifactMetadataSource = UpdateParentMojoTest.artifactMetadataSource;
-            resolver = UpdateParentMojoTest.this.artifactResolver;
-
             setVariableValueToObject( this, "changeRecorder", changeRecorder );
         }};
     }

--- a/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
@@ -62,7 +62,11 @@ public class UseLatestVersionsMojoTest
                     "1.0.0.0-SNAPSHOT", "0.9.0.0"} );
         }} );
 
-        mojo = new UseLatestVersionsMojo()
+        mojo = new UseLatestVersionsMojo( repositorySystemMock,
+                null,
+                artifactMetadataSourceMock,
+                null,
+                null )
         {{
             MavenProject project = new MavenProject()
             {{
@@ -83,8 +87,6 @@ public class UseLatestVersionsMojoTest
                 }} );
             }};
             setProject( project );
-            repositorySystem = repositorySystemMock;
-            artifactMetadataSource = artifactMetadataSourceMock;
 
             changeRecorder = new TestChangeRecorder();
             setVariableValueToObject( this, "changeRecorder", changeRecorder );

--- a/src/test/java/org/codehaus/mojo/versions/utils/MockUtils.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/MockUtils.java
@@ -28,8 +28,12 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.doxia.tools.SiteTool;
+import org.apache.maven.doxia.tools.SiteToolException;
+import org.codehaus.plexus.i18n.I18N;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,5 +86,29 @@ public class MockUtils
             throw new RuntimeException( e );
         }
         return artifactMetadataSource;
+    }
+
+    public static I18N mockI18N()
+    {
+        I18N i18n = mock( I18N.class );
+        when( i18n.getString( anyString(), any(), anyString() ) ).thenAnswer(
+            invocation -> invocation.getArgument( 2 ) );
+        return i18n;
+    }
+
+    public static SiteTool mockSiteTool()
+    {
+        Artifact skinArtifact = mock( Artifact.class );
+        when( skinArtifact.getId() ).thenReturn( "" );
+        SiteTool siteTool = mock( SiteTool.class );
+        try
+        {
+            when( siteTool.getSkinArtifactFromRepository( any(), any(), any() ) ).thenReturn( skinArtifact );
+        }
+        catch ( SiteToolException e )
+        {
+            throw new RuntimeException( e );
+        }
+        return siteTool;
     }
 }


### PR DESCRIPTION
Migrating to JSR330. Notable find: removed the bogus duplicate of the ArtifactResolver component in AbstractVersionsUpdaterMojo (there are two which point to the same component).

Using constructor-style injection, as advised in the reference.