### PR TITLE
#632 Second batch of maintenance following PR #672

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestReleasesMojo.java
@@ -50,7 +50,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
-import org.codehaus.mojo.versions.ordering.MajorMinorIncrementalFilter;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 
@@ -151,8 +150,6 @@ public class UseLatestReleasesMojo
     {
         Optional<Segment> unchangedSegment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
                 allowIncrementalUpdates );
-        MajorMinorIncrementalFilter majorMinorIncfilter =
-            new MajorMinorIncrementalFilter( allowMajorUpdates, allowMinorUpdates, allowIncrementalUpdates );
 
         for ( Dependency dep : dependencies )
         {
@@ -185,10 +182,9 @@ public class UseLatestReleasesMojo
                 ArtifactVersions versions = getHelper().lookupArtifactVersions( artifact, false );
                 try
                 {
-                    ArtifactVersion[] newer = versions.getNewerVersions( version, unchangedSegment, false );
-                    newer = filterVersionsWithIncludes( newer, artifact );
-
-                    ArtifactVersion[] filteredVersions = majorMinorIncfilter.filter( selectedVersion, newer );
+                    // TODO consider creating a search + filter in the Details services to get latest release.
+                    ArtifactVersion[] newer = versions.getNewerVersions( version, unchangedSegment, false, false );
+                    ArtifactVersion[] filteredVersions = filterVersionsWithIncludes( newer, artifact );
                     if ( filteredVersions.length > 0 )
                     {
                         String newVersion = filteredVersions[filteredVersions.length - 1].toString();

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojo.java
@@ -48,7 +48,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
-import org.codehaus.mojo.versions.ordering.MajorMinorIncrementalFilter;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
@@ -151,8 +150,6 @@ public class UseLatestSnapshotsMojo
     {
         Optional<Segment> unchangedSegment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
                 allowIncrementalUpdates );
-        MajorMinorIncrementalFilter majorMinorIncfilter =
-            new MajorMinorIncrementalFilter( allowMajorUpdates, allowMinorUpdates, allowIncrementalUpdates );
 
         for ( Dependency dep : dependencies )
         {
@@ -201,6 +198,7 @@ public class UseLatestSnapshotsMojo
                     ArtifactVersion[] newer = versions.getVersions( restriction, true );
                     getLog().debug( "Candidate versions " + Arrays.asList( newer ) );
 
+                    // TODO consider creating a search + filter in the Details services to get latest snapshot.
                     String latestVersion;
                     ArrayList<ArtifactVersion> snapshotsOnly = new ArrayList<>();
 
@@ -212,13 +210,8 @@ public class UseLatestSnapshotsMojo
                             snapshotsOnly.add( artifactVersion );
                         }
                     }
-                    getLog().debug( "Snapshot Only versions " + snapshotsOnly );
-
-                    ArtifactVersion[] filteredVersions = majorMinorIncfilter.filter(
-                            selectedVersion, snapshotsOnly.toArray( new ArtifactVersion[0] ) );
-                    getLog().debug( "Filtered versions " + Arrays.asList( filteredVersions ) );
-
-
+                    ArtifactVersion[] filteredVersions = snapshotsOnly.toArray(
+                            new ArtifactVersion[snapshotsOnly.size()] );
                     if ( filteredVersions.length > 0 )
                     {
                         latestVersion = filteredVersions[filteredVersions.length - 1].toString();

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -45,6 +45,7 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
+import org.codehaus.mojo.versions.ordering.MajorMinorIncrementalFilter;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 
@@ -166,6 +167,8 @@ public class UseLatestVersionsMojo
     {
         Optional<Segment> unchangedSegment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
                 allowIncrementalUpdates );
+        MajorMinorIncrementalFilter majorMinorIncfilter =
+            new MajorMinorIncrementalFilter( allowMajorUpdates, allowMinorUpdates, allowIncrementalUpdates );
 
         for ( Dependency dep : dependencies )
         {
@@ -197,9 +200,10 @@ public class UseLatestVersionsMojo
             try
             {
                 // TODO consider creating a getNewestVersion method in the Details services.
-                ArtifactVersion[] filteredVersions = versions.getNewerVersions( version, unchangedSegment,
-                        allowSnapshots, allowDowngrade );
+                ArtifactVersion[] newerVersions = versions.getNewerVersions( version, unchangedSegment, allowSnapshots,
+                        allowDowngrade );
 
+                ArtifactVersion[] filteredVersions = majorMinorIncfilter.filter( selectedVersion, newerVersions );
                 if ( filteredVersions.length > 0 )
                 {
                     String newVersion = filteredVersions[filteredVersions.length - 1].toString();

--- a/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -45,7 +45,6 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
-import org.codehaus.mojo.versions.ordering.MajorMinorIncrementalFilter;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 
@@ -167,8 +166,6 @@ public class UseLatestVersionsMojo
     {
         Optional<Segment> unchangedSegment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
                 allowIncrementalUpdates );
-        MajorMinorIncrementalFilter majorMinorIncfilter =
-            new MajorMinorIncrementalFilter( allowMajorUpdates, allowMinorUpdates, allowIncrementalUpdates );
 
         for ( Dependency dep : dependencies )
         {
@@ -199,10 +196,10 @@ public class UseLatestVersionsMojo
 
             try
             {
-                ArtifactVersion[] newerVersions = versions.getNewerVersions( version, unchangedSegment, allowSnapshots,
-                        allowDowngrade );
+                // TODO consider creating a getNewestVersion method in the Details services.
+                ArtifactVersion[] filteredVersions = versions.getNewerVersions( version, unchangedSegment,
+                        allowSnapshots, allowDowngrade );
 
-                ArtifactVersion[] filteredVersions = majorMinorIncfilter.filter( selectedVersion, newerVersions );
                 if ( filteredVersions.length > 0 )
                 {
                     String newVersion = filteredVersions[filteredVersions.length - 1].toString();

--- a/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -266,6 +266,7 @@ public abstract class AbstractVersionDetails
                 : getVersionComparator().incrementSegment( lowerBound, upperBoundSegment.get() );
 
         Restriction restriction = new Restriction( lowerBound, allowDowngrade, upperBound, allowDowngrade );
+        // TODO shouldn't allowDowngrade boolean be passed to this call ?
         return getVersions( restriction, includeSnapshots );
     }
 


### PR DESCRIPTION
Second batch of maintenance following PR #672.

"as a result of fixing #632, it appears we could maybe get rid of the class MajorMinorIncrementalFilter which states that its very existence is filtering milestones and RC from the result of the calls, when they are in the wrong major, but they are now already filtered out by the corrected boundaries."
