### PR TITLE
Issue #265: revert mojo to scan child modules instead of relying on maven

### DIFF
--- a/src/it/it-revert-isssue-265/aggregate/pom.xml
+++ b/src/it/it-revert-isssue-265/aggregate/pom.xml
@@ -1,0 +1,21 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact</artifactId>
+    <version>OLD</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>../module-a</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>module-b</id>
+
+            <modules>
+                <module>../module-b</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/src/it/it-revert-isssue-265/invoker.properties
+++ b/src/it/it-revert-isssue-265/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:set -f aggregate/pom.xml
+invoker.mavenOpts.1 = -DnewVersion=1.2.3 -DprocessAllModules
+
+invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:revert -f aggregate/pom.xml

--- a/src/it/it-revert-isssue-265/module-a/pom.xml
+++ b/src/it/it-revert-isssue-265/module-a/pom.xml
@@ -1,0 +1,15 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact-a</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-artifact</artifactId>
+            <version>OLD</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/it-revert-isssue-265/module-b/pom.xml
+++ b/src/it/it-revert-isssue-265/module-b/pom.xml
@@ -1,0 +1,17 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact-b</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>localhost</groupId>
+                <artifactId>dummy-artifact</artifactId>
+                <version>OLD</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/it-revert-isssue-265/verify.groovy
+++ b/src/it/it-revert-isssue-265/verify.groovy
@@ -1,0 +1,8 @@
+assert new File( basedir, "aggregate/pom.xml" ).text =~ /OLD/
+assert !new File( basedir, "aggregate/pom.xml.versionsBackup" ).exists()
+
+assert new File( basedir, "module-a/pom.xml" ).text =~ /OLD/
+assert !new File( basedir, "module-a/pom.xml.versionsBackup" ).exists()
+
+assert new File( basedir, "module-b/pom.xml" ).text =~ /OLD/
+assert !new File( basedir, "module-b/pom.xml.versionsBackup" ).exists()

--- a/src/test/java/org/codehaus/mojo/versions/RevertMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/RevertMojoTest.java
@@ -1,0 +1,93 @@
+package org.codehaus.mojo.versions;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+
+import static java.lang.String.join;
+import static org.apache.commons.io.FileUtils.copyDirectory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Unit tests for {@link RevertMojo}
+ *
+ * @author Andrzej Jarmoniuk
+ */
+public class RevertMojoTest extends AbstractMojoTestCase
+{
+    @Rule
+    public MojoRule mojoRule = new MojoRule( this );
+    private Path pomDir;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        super.setUp();
+        pomDir = Files.createTempDirectory( "revert-" );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        try
+        {
+            if ( pomDir != null && pomDir.toFile().exists() )
+            {
+                Arrays.stream( Objects.requireNonNull( pomDir.toFile().listFiles() ) ).forEach( File::delete );
+                pomDir.toFile().delete();
+            }
+        }
+        finally
+        {
+            super.tearDown();
+        }
+    }
+
+    public void testRevert() throws Exception
+    {
+        copyDirectory( new File( getBasedir(),
+                "target/test-classes/org/codehaus/mojo/revert/issue-265" ), pomDir.toFile() );
+        RevertMojo myMojo = (RevertMojo) mojoRule.lookupConfiguredMojo(
+                new File( pomDir.toString(), "aggregate" ), "revert" );
+        myMojo.execute();
+
+        assertThat( join( "\n", Files.readAllLines( pomDir.resolve( "aggregate/pom.xml" ) ) ),
+                containsString( "OLD" ) );
+        assertThat( Files.exists( pomDir.resolve( "aggregate/pom.xml.versionsBackup" ) ), is( false ) );
+        assertThat( join( "\n", Files.readAllLines( pomDir.resolve( "module-a/pom.xml" ) ) ),
+                containsString( "OLD" ) );
+        assertThat( Files.exists( pomDir.resolve( "module-a/pom.xml.versionsBackup" ) ), is( false ) );
+        assertThat( join( "\n", Files.readAllLines( pomDir.resolve( "module-b/pom.xml" ) ) ),
+                containsString( "OLD" ) );
+        assertThat( Files.exists( pomDir.resolve( "module-b/pom.xml.versionsBackup" ) ), is( false ) );
+    }
+}

--- a/src/test/resources/org/codehaus/mojo/revert/issue-265/aggregate/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/revert/issue-265/aggregate/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact</artifactId>
+    <version>NEW</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>../module-a</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>module-b</id>
+
+            <modules>
+                <module>../module-b</module>
+            </modules>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <goals>
+                    <goal>revert</goal>
+                </goals>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/org/codehaus/mojo/revert/issue-265/aggregate/pom.xml.versionsBackup
+++ b/src/test/resources/org/codehaus/mojo/revert/issue-265/aggregate/pom.xml.versionsBackup
@@ -1,0 +1,21 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact</artifactId>
+    <version>OLD</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>../module-a</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>module-b</id>
+
+            <modules>
+                <module>../module-b</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/src/test/resources/org/codehaus/mojo/revert/issue-265/module-a/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/revert/issue-265/module-a/pom.xml
@@ -1,0 +1,15 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact-a</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-artifact</artifactId>
+            <version>NEW</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/org/codehaus/mojo/revert/issue-265/module-a/pom.xml.versionsBackup
+++ b/src/test/resources/org/codehaus/mojo/revert/issue-265/module-a/pom.xml.versionsBackup
@@ -1,0 +1,15 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact-a</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-artifact</artifactId>
+            <version>OLD</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/org/codehaus/mojo/revert/issue-265/module-b/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/revert/issue-265/module-b/pom.xml
@@ -1,0 +1,17 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact-b</artifactId>
+    <version>NEW</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>localhost</groupId>
+                <artifactId>dummy-artifact</artifactId>
+                <version>VERSION</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/test/resources/org/codehaus/mojo/revert/issue-265/module-b/pom.xml.versionsBackup
+++ b/src/test/resources/org/codehaus/mojo/revert/issue-265/module-b/pom.xml.versionsBackup
@@ -1,0 +1,17 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-artifact-b</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>localhost</groupId>
+                <artifactId>dummy-artifact</artifactId>
+                <version>OLD</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>


### PR DESCRIPTION
Using `PomHelper::getAllChildModules` to retrieve all modules in the reactor to get files to revert. Relying on maven to process all enabled profiles did not revert all files changed by `SetMojo`, because `SetMojo` also uses `getAllChildModules`.