### PR TITLE
#717: Changing the reserved prefix to "versions"

### DIFF
--- a/src/it/it-display-dependency-updates-001/invoker.properties
+++ b/src/it/it-display-dependency-updates-001/invoker.properties
@@ -2,4 +2,4 @@ invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:di
 invoker.mavenOpts.1 = -Dversions.outputFile=./output1.txt -DoutputEncoding=UTF-8
 
 invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
-invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dmaven.version.ignore=3.0
+invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dversions.ignore=3.0

--- a/src/it/it-display-dependency-updates-issue-684-pom-based-rules/invoker.properties
+++ b/src/it/it-display-dependency-updates-issue-684-pom-based-rules/invoker.properties
@@ -2,4 +2,4 @@ invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:di
 invoker.mavenOpts.1 = -Dversions.outputFile=./output1.txt -DoutputEncoding=UTF-8
 
 invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
-invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dmaven.version.ignore=2.1
+invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dversions.ignore=2.1

--- a/src/it/it-display-plugin-updates-001/invoker.properties
+++ b/src/it/it-display-plugin-updates-001/invoker.properties
@@ -2,5 +2,5 @@ invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:disp
 invoker.mavenOpts.1 = -Dversions.outputFile=./output1.txt -DoutputEncoding=UTF-8
 
 invoker.goals.2=${project.groupId}:${project.artifactId}:${project.version}:display-plugin-updates
-invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dmaven.version.ignore=3.0
+invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dversions.ignore=3.0
 

--- a/src/it/it-display-plugin-updates-issue-684-pom-based-rules/invoker.properties
+++ b/src/it/it-display-plugin-updates-issue-684-pom-based-rules/invoker.properties
@@ -2,4 +2,4 @@ invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:di
 invoker.mavenOpts.1 = -Dversions.outputFile=./output1.txt -DoutputEncoding=UTF-8
 
 invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:display-plugin-updates
-invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dmaven.version.ignore=2.1
+invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -Dversions.ignore=2.1

--- a/src/it/it-display-property-updates-001/invoker.properties
+++ b/src/it/it-display-property-updates-001/invoker.properties
@@ -2,4 +2,4 @@ invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:di
 invoker.mavenOpts.1 = -Dversions.outputFile=./output1.txt -DoutputEncoding=UTF-8 -DautoLinkItems=true
 
 invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:display-property-updates
-invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -DautoLinkItems=true -Dmaven.version.ignore=2.0
+invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -DautoLinkItems=true -Dversions.ignore=2.0

--- a/src/it/it-display-property-updates-issue-684-pom-based-rules/invoker.properties
+++ b/src/it/it-display-property-updates-issue-684-pom-based-rules/invoker.properties
@@ -2,4 +2,4 @@ invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:di
 invoker.mavenOpts.1 = -Dversions.outputFile=./output1.txt -DoutputEncoding=UTF-8 -DautoLinkItems=true
 
 invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:display-property-updates
-invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -DautoLinkItems=true -Dmaven.version.ignore=1.3
+invoker.mavenOpts.2 = -Dversions.outputFile=./output2.txt -DoutputEncoding=UTF-8 -DautoLinkItems=true -Dversions.ignore=1.3

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -108,21 +108,23 @@ public abstract class AbstractVersionsReport
     private Settings settings;
 
     /**
-     * settings.xml's server id for the URL. This is used when wagon needs extra authentication information.
-     *
+     * <p>settings.xml's server id for the URL. This is used when wagon needs extra authentication information.</p>
+     * <p><em>Before version 2.13.0 the user property was {@code maven.version.rules.serverId}</em></p>
      * @since 1.0-alpha-3
      */
-    @Parameter( property = "maven.version.rules.serverId", defaultValue = "serverId" )
+    @Parameter( property = "versions.rules.serverId", defaultValue = "serverId" )
     private String serverId;
-
+    
     /**
-     * URI of a ruleSet file containing the rules that control how to compare
+     * <p>URI of a ruleSet file containing the rules that control how to compare
      * version numbers. The URI could be either a Wagon URI or a classpath URI
-     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).
+     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).</p>
+     *
+     * <p><em>Before version 2.13.0 the user property was {@code maven.version.rules}</em></p>
      *
      * @since 1.0-alpha-3
      */
-    @Parameter( property = "maven.version.rules" )
+    @Parameter( property = "versions.rules" )
     private String rulesUri;
 
     /**
@@ -183,9 +185,10 @@ public abstract class AbstractVersionsReport
      * </p>
      *
      * <p><em>Currently, this parameter will override the defined {@link #ruleSet}</em></p>
+     *
      * @since 2.13.0
      */
-    @Parameter( property = "maven.version.ignore" )
+    @Parameter( property = "versions.ignore" )
     protected Set<String> ignoredVersions;
 
     // --------------------- GETTER / SETTER METHODS ---------------------

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -145,21 +145,23 @@ public abstract class AbstractVersionsUpdaterMojo
     protected Settings settings;
 
     /**
-     * settings.xml's server id for the URL. This is used when wagon needs extra authentication information.
-     *
+     * <p>settings.xml's server id for the URL. This is used when wagon needs extra authentication information.</p>
+     * <p><em>Before version 2.13.0 the user property was {@code maven.version.rules.serverId}</em></p>
      * @since 1.0-alpha-3
      */
-    @Parameter( property = "maven.version.rules.serverId", defaultValue = "serverId" )
+    @Parameter( property = "versions.rules.serverId", defaultValue = "serverId" )
     private String serverId;
 
     /**
-     * URI of a ruleSet file containing the rules that control how to compare
+     * <p>URI of a ruleSet file containing the rules that control how to compare
      * version numbers. The URI could be either a Wagon URI or a classpath URI
-     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).
+     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).</p>
      *
+     * <p><em>Before version 2.13.0 the user property was {@code maven.version.rules}</em></p>
+     * 
      * @since 1.0-alpha-3
      */
-    @Parameter( property = "maven.version.rules" )
+    @Parameter( property = "versions.rules" )
     private String rulesUri;
 
     /**
@@ -240,7 +242,7 @@ public abstract class AbstractVersionsUpdaterMojo
      * <p><em>Currently, this parameter will override the defined {@link #ruleSet}</em></p>
      * @since 2.13.0
      */
-    @Parameter( property = "maven.version.ignore" )
+    @Parameter( property = "versions.ignore" )
     protected Set<String> ignoredVersions;
 
     // --------------------- GETTER / SETTER METHODS ---------------------

--- a/src/site/apt/version-rules.apt.vm
+++ b/src/site/apt/version-rules.apt.vm
@@ -62,7 +62,7 @@ Version number rules
 
   To specify the version schemes to use, you may define a {{{./rule.html}rule-set xml file}}, use the <<<ruleSet>>>
   element in the <<<versions-maven-plugin>>> plugin configuration, or specify ignored versions via
-  the <<<maven.version.ignore>>> property.
+  the <<<versions.ignore>>> property.
 
 ** Using the <<<Rules.xml>>> file
 
@@ -147,9 +147,9 @@ Version number rules
       </ruleSet>
 ---
 
-** Using the <<<maven.version.ignore>>> property
+** Using the <<<versions.ignore>>> property
 
-  The <<<maven.version.ignore>>> property can list *comma-separated* list of global version **regex** patterns, which
+  The <<<versions.ignore>>> property can list *comma-separated* list of global version **regex** patterns, which
   will be ignored when considering available versions.
 
   Examples:
@@ -164,7 +164,7 @@ Version number rules
 
   It is possible to ignore versions on a global and on a per-rule basis.
 
-  The other methods (via the <<<<ruleSet>>>> element and via the <<<maven.version.ignore>>>) property have been
+  The other methods (via the <<<<ruleSet>>>> element and via the <<<versions.ignore>>>) property have been
   explained above. The described
 
 ---


### PR DESCRIPTION
Alternative to #718, changing the prefix to "versions" since it's already being used for `versions.skip`.