### PR TITLE
#454: Introducing "infinity-like" range calculus for dependency range computation

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -60,7 +60,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
 
     /**
      * A comma separated list of artifact patterns to include. Follows the pattern
-     * "groupId:artifactId:type:classifier:version". Designed to allow specifing the set of includes from the command
+     * "groupId:artifactId:type:classifier:version". Designed to allow specifying the set of includes from the command
      * line. When specifying includes from the pom, use the {@link #includes} configuration instead. If this property is
      * specified then the {@link # include} configuration is ignored.
      *
@@ -71,7 +71,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo
 
     /**
      * A comma separated list of artifact patterns to exclude. Follows the pattern
-     * "groupId:artifactId:type:classifier:version". Designed to allow specifing the set of excludes from the command
+     * "groupId:artifactId:type:classifier:version". Designed to allow specifying the set of excludes from the command
      * line. When specifying excludes from the pom, use the {@link #excludes} configuration instead. If this property is
      * specified then the {@link # exclude} configuration is ignored.
      *

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReportRenderer.java
@@ -780,40 +780,47 @@ public abstract class AbstractVersionsReportRenderer
 
     protected String getLabel( ArtifactVersion version, AbstractVersionDetails versions )
     {
-        String label = null;
+        if ( equals( version, versions.getNewestUpdate( of( SUBINCREMENTAL ) ) ) )
+        {
+            return getText( "report.latestSubIncremental" );
+        }
+
+        if ( equals( version, versions.getOldestUpdate( of( SUBINCREMENTAL ) ) ) )
+        {
+            return getText( "report.nextVersion" );
+        }
+
+        if ( equals( version, versions.getOldestUpdate( of( INCREMENTAL ) ) ) )
+        {
+            return getText( "report.nextIncremental" );
+        }
+
+        if ( equals( version, versions.getNewestUpdate( of( INCREMENTAL ) ) ) )
+        {
+            return getText( "report.latestIncremental" );
+        }
+
+        if ( equals( version, versions.getOldestUpdate( of( MINOR ) ) ) )
+        {
+            return getText( "report.nextMinor" );
+        }
+
+        if ( equals( version, versions.getNewestUpdate( of( MINOR ) ) ) )
+        {
+            return getText( "report.latestMinor" );
+        }
+
+        if ( equals( version, versions.getOldestUpdate( of( MAJOR ) ) ) )
+        {
+            return getText( "report.nextMajor" );
+        }
+
         if ( equals( version, versions.getNewestUpdate( of( MAJOR ) ) ) )
         {
-            label = getText( "report.latestMajor" );
+            return getText( "report.latestMajor" );
         }
-        else if ( equals( version, versions.getOldestUpdate( of( MAJOR ) ) ) )
-        {
-            label = getText( "report.nextMajor" );
-        }
-        else if ( equals( version, versions.getNewestUpdate( of( MINOR ) ) ) )
-        {
-            label = getText( "report.latestMinor" );
-        }
-        else if ( equals( version, versions.getOldestUpdate( of( MINOR ) ) ) )
-        {
-            label = getText( "report.nextMinor" );
-        }
-        else if ( equals( version, versions.getNewestUpdate( of( INCREMENTAL ) ) ) )
-        {
-            label = getText( "report.latestIncremental" );
-        }
-        else if ( equals( version, versions.getOldestUpdate( of( INCREMENTAL ) ) ) )
-        {
-            label = getText( "report.nextIncremental" );
-        }
-        else if ( equals( version, versions.getNewestUpdate( of( SUBINCREMENTAL ) ) ) )
-        {
-            label = getText( "report.latestSubIncremental" );
-        }
-        else if ( equals( version, versions.getOldestUpdate( of( SUBINCREMENTAL ) ) ) )
-        {
-            label = getText( "report.nextVersion" );
-        }
-        return label;
+
+        return "";
     }
 
 }

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -356,6 +356,7 @@ public abstract class AbstractVersionsUpdaterMojo
      * @param versionRange          The version range.
      * @param allowingSnapshots     <code>null</code> for no override, otherwise the local override to apply.
      * @param usePluginRepositories Use plugin repositories
+     * @param allowDowngrade        whether downgrades should be allowed
      * @return The latest version of the specified artifact that matches the specified version range or
      * <code>null</code> if no matching version could be found.
      * @throws ArtifactMetadataRetrievalException If the artifact metadata could not be found.
@@ -515,6 +516,7 @@ public abstract class AbstractVersionsUpdaterMojo
      * @param artifact       The artifact.
      * @param currentVersion The current version of the artifact.
      * @param updateVersion  The proposed new version of the artifact.
+     * @param forceUpdate    if true, LATEST and RELEASE versions will be overwritten with the real version
      * @return <code>true</code> if the update should be applied to the pom.
      * @since 2.9
      */
@@ -575,7 +577,7 @@ public abstract class AbstractVersionsUpdaterMojo
      * @param allowMajorUpdates       Allow major updates
      * @param allowMinorUpdates       Allow minor updates
      * @param allowIncrementalUpdates Allow incremental updates
-     * @return Returns the segment (0-based) that is unchangable. If any segment can change, returns -1.
+     * @return Returns the segment (0-based) that is unchangeable. If any segment can change, returns -1.
      */
     protected Optional<Segment> determineUnchangedSegment( boolean allowMajorUpdates, boolean allowMinorUpdates,
                                                            boolean allowIncrementalUpdates )

--- a/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
@@ -65,7 +65,7 @@ public class DependencyUpdatesReport extends AbstractVersionsReport
     protected boolean processDependencyManagement;
 
     /**
-     * Whether to process the depdendencyManagement part transitive or not.
+     * Whether to process the dependencyManagement part transitive or not.
      * In case of <code>&lt;type&gt;pom&lt;/type&gt;</code>and
      * <code>&lt;scope&gt;import&lt;/scope&gt;</code> this means
      * by default to report also the imported dependencies.

--- a/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -94,7 +94,7 @@ public class DisplayDependencyUpdatesMojo
     private boolean processDependencyManagement;
 
     /**
-     * Whether to process the depdendencyManagement part transitive or not.
+     * Whether to process the dependencyManagement part transitive or not.
      * In case of <code>&lt;type&gt;pom&lt;/type&gt;</code>and
      * <code>&lt;scope&gt;import&lt;/scope&gt;</code> this means
      * by default to report also the imported dependencies.
@@ -691,12 +691,28 @@ public class DisplayDependencyUpdatesMojo
 
     private Optional<Segment> calculateUpdateScope()
     {
-        return !allowAnyUpdates
-                ? allowMajorUpdates ? of( MAJOR )
-                : allowMinorUpdates ? of( MINOR )
-                : allowIncrementalUpdates ? of( INCREMENTAL )
-                : empty()
-                : empty();
+        if ( !allowIncrementalUpdates && !allowMinorUpdates && !allowMajorUpdates && !allowAnyUpdates )
+        {
+            throw new IllegalArgumentException( "One of: allowAnyUpdates, allowMajorUpdates, allowMinorUpdates, "
+                    + "allowIncrementalUpdates must be true" );
+        }
+
+        if ( allowAnyUpdates && allowMajorUpdates && allowMinorUpdates )
+        {
+            return empty();
+        }
+
+        if ( allowMajorUpdates && allowMinorUpdates )
+        {
+            return of( MAJOR );
+        }
+
+        if ( allowMinorUpdates )
+        {
+            return of( MINOR );
+        }
+
+        return of( INCREMENTAL );
     }
 
     private void logUpdates( Map<Dependency, ArtifactVersions> updates, String section )

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -402,9 +402,10 @@ public class SetMojo extends AbstractVersionsUpdaterMojo
 
     /**
      * Returns the incremented version, with the nextSnapshotIndexToIncrement indicating the 1-based index,
-     * conunting from the left, or the most major version component, of the version string.
+     * from the left, or the most major version component, of the version string.
      *
      * @param version input version
+     * @param nextSnapshotIndexToIncrement 1-based segment number to be incremented
      * @return version with the incremented index specified by nextSnapshotIndexToIncrement or last index
      * @throws MojoExecutionException thrown if the input parameters are invalid
      */

--- a/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -1476,9 +1476,10 @@ public class PomHelper
      * Finds the local root of the specified project.
      *
      * @param project              The project to find the local root for.
+     * @param builder              {@linkplain MavenProjectBuilder} object
      * @param localRepository      the local repo.
      * @param globalProfileManager the global profile manager.
-     * @param logger               The logger to log to.
+     * @param logger               The logger to log tog
      * @return The local root (note this may be the project passed as an argument).
      */
     public static MavenProject getLocalRoot( MavenProjectBuilder builder, MavenProject project,

--- a/src/main/java/org/codehaus/mojo/versions/api/Segment.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/Segment.java
@@ -26,14 +26,7 @@ package org.codehaus.mojo.versions.api;
  */
 public enum Segment implements Comparable<Segment>
 {
-    MAJOR( 0 ), MINOR( 1 ), INCREMENTAL( 2 ), SUBINCREMENTAL( 3 );
-
-    private final int index;
-
-    Segment( int index )
-    {
-        this.index = index;
-    }
+    MAJOR, MINOR, INCREMENTAL, SUBINCREMENTAL;
 
     /**
      * Returns the 0-based sendex index
@@ -42,20 +35,26 @@ public enum Segment implements Comparable<Segment>
      */
     public int value()
     {
-        return index;
+        return ordinal();
     }
 
     public static Segment of( int index )
     {
-        switch ( index )
+        if ( index < 0 || index > 3 )
         {
-            case 0: return MAJOR;
-            case 1: return MINOR;
-            case 2: return INCREMENTAL;
-            case 3: return SUBINCREMENTAL;
-            default:
-                throw new IllegalArgumentException( "Wrong segment index: " + index );
+            throw new IllegalArgumentException( "Wrong segment index: " + index );
         }
+        return values()[index];
+    }
+
+    /**
+     * Returns true if the given segment is more major than the other
+     * @param other other segment to compare
+     * @return true if the given segment is more major
+     */
+    public boolean isMajorTo( Segment other )
+    {
+        return value() < other.value();
     }
 
     @Override

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -221,6 +221,7 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestUpdate( ArtifactVersion currentVersion, Optional<Segment> updateScope,
@@ -235,6 +236,7 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion getNewestUpdate( ArtifactVersion currentVersion, Optional<Segment> updateScope,
@@ -247,6 +249,7 @@ public interface VersionDetails
      * @param updateScope the update scope to include.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion[] getAllUpdates( ArtifactVersion currentVersion, Optional<Segment> updateScope,
@@ -295,6 +298,7 @@ public interface VersionDetails
      * @param updateScope the update scope to include.
      * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestUpdate( Optional<Segment> updateScope ) throws InvalidSegmentException;
@@ -306,6 +310,7 @@ public interface VersionDetails
      * @param updateScope the update scope to include.
      * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion getNewestUpdate( Optional<Segment> updateScope ) throws InvalidSegmentException;
@@ -315,6 +320,7 @@ public interface VersionDetails
      *
      * @param updateScope the update scope to include.
      * @return the all versions after currentVersion within the specified update scope.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion[] getAllUpdates( Optional<Segment> updateScope ) throws InvalidSegmentException;
@@ -327,6 +333,7 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the oldest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion getOldestUpdate( Optional<Segment> updateScope, boolean includeSnapshots )
@@ -340,6 +347,7 @@ public interface VersionDetails
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion getNewestUpdate( Optional<Segment> updateScope, boolean includeSnapshots )
@@ -351,6 +359,7 @@ public interface VersionDetails
      * @param updateScope the update scope to include.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
+     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
      */
     ArtifactVersion[] getAllUpdates( Optional<Segment> updateScope, boolean includeSnapshots )

--- a/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
@@ -59,8 +59,17 @@ public abstract class AbstractVersionComparator
      */
     public final ArtifactVersion incrementSegment( ArtifactVersion v, Segment segment ) throws InvalidSegmentException
     {
-        return VersionComparators.copySnapshot( v, innerIncrementSegment( VersionComparators.stripSnapshot( v ),
-                                                                          segment ) );
+        if ( VersionComparators.isSnapshot( v ) )
+        {
+            return VersionComparators.copySnapshot( v, innerIncrementSegment( VersionComparators.stripSnapshot( v ),
+                    segment ) );
+        }
+        int segmentCount = getSegmentCount( v );
+        if ( segment.value() >= segmentCount )
+        {
+            throw new InvalidSegmentException( segment, segmentCount, v );
+        }
+        return innerIncrementSegment( v, segment );
     }
 
     protected abstract ArtifactVersion innerIncrementSegment( ArtifactVersion v, Segment segment )

--- a/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
@@ -1,0 +1,93 @@
+package org.codehaus.mojo.versions.ordering;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.mojo.versions.api.Segment;
+
+import static org.codehaus.mojo.versions.ordering.ComparableVersion.IntegerItem.ZERO;
+
+/**
+ * <p>Represents an artifact version with all segments more major or equal to a given segment
+ * held in place. It can be thought of as an artifact having +&infin; as its upper bound
+ * on all segments less major than the held segment.</p>
+ * <p>When compared with another artifact versions, this results with the other object
+ * with the segment versions up to the held segment being equal,
+ * always comparing lower than this object.</p>
+ * <p>This is particularly helpful for -SNAPSHOT and other versions with qualifiers, which
+ * are lower than version 0 in the Maven versioning system.</p>
+ */
+public class BoundArtifactVersion extends DefaultArtifactVersion
+{
+    /**
+     * Most major segment that can change, i.e. not held in place.
+     * All segments that are more major than this one are held in place.
+     */
+    private final Segment segment;
+
+    private final BoundComparableVersion comparator;
+
+    /**
+     * Constructs the instance
+     * @param artifactVersion artifact version containing the segment version values
+     * @param segment most major segment that can change, i.e. <em>not</em> held in place
+     */
+    public BoundArtifactVersion( ArtifactVersion artifactVersion, Segment segment )
+    {
+        super( artifactVersion.toString() );
+        this.segment = segment;
+        this.comparator = new BoundComparableVersion( this );
+    }
+
+    /**
+     * Returns the most major segment that can change.
+     * All segments that are more major than this one are held in place.
+     * @return segment that can change
+     */
+    public Segment getSegment()
+    {
+        return segment;
+    }
+
+    @Override
+    public int compareTo( ArtifactVersion other )
+    {
+        if ( other == null )
+        {
+            return -1;
+        }
+
+        return comparator.compareTo( new ComparableVersion( other.toString() ) );
+    }
+
+    protected static class BoundComparableVersion extends ComparableVersion
+    {
+        private BoundArtifactVersion artifactVersion;
+        protected BoundComparableVersion( BoundArtifactVersion artifactVersion )
+        {
+            super( artifactVersion.toString() );
+            this.artifactVersion = artifactVersion;
+        }
+
+        @Override
+        public int compareTo( ComparableVersion o )
+        {
+            return compareTo( ( (List<Item>) items ).iterator(),
+                    ( (Iterable<Item>) o.items ).iterator(), artifactVersion.segment.value() );
+
+        }
+
+        @SuppressWarnings( "checkstyle:InnerAssignment" )
+        private int compareTo( Iterator<Item> left, Iterator<Item> right, int comparisonLimit )
+        {
+            int r;
+            return !( comparisonLimit > 0 && right.hasNext() )
+                    ? 1
+                    : ( r = -( right.next().compareTo( left.hasNext() ? left.next() : ZERO ) ) ) != 0
+                            ? r
+                            : compareTo( left, right, comparisonLimit - 1 );
+        }
+    }
+}

--- a/src/main/java/org/codehaus/mojo/versions/ordering/ComparableVersion.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/ComparableVersion.java
@@ -43,9 +43,9 @@ public class ComparableVersion
 
     private String canonical;
 
-    private ListItem items;
+    protected ListItem items;
 
-    private interface Item
+    protected interface Item
     {
         int INTEGER_ITEM = 0;
 
@@ -63,10 +63,10 @@ public class ComparableVersion
     /**
      * Represents a numeric item in the version item list.
      */
-    private static class IntegerItem
+    protected static class IntegerItem
         implements Item
     {
-        private static final BigInteger BIG_INTEGEGER_ZERO = new BigInteger( "0" );
+        private static final BigInteger BIG_INTEGER_ZERO = new BigInteger( "0" );
 
         private final BigInteger value;
 
@@ -74,7 +74,7 @@ public class ComparableVersion
 
         private IntegerItem()
         {
-            this.value = BIG_INTEGEGER_ZERO;
+            this.value = BIG_INTEGER_ZERO;
         }
 
         IntegerItem( String str )
@@ -89,14 +89,14 @@ public class ComparableVersion
 
         public boolean isNull()
         {
-            return BIG_INTEGEGER_ZERO.equals( value );
+            return BIG_INTEGER_ZERO.equals( value );
         }
 
         public int compareTo( Item item )
         {
             if ( item == null )
             {
-                return BIG_INTEGEGER_ZERO.equals( value ) ? 0 : 1; // 1.0 == 1, 1.1 > 1
+                return BIG_INTEGER_ZERO.equals( value ) ? 0 : 1; // 1.0 == 1, 1.1 > 1
             }
 
             switch ( item.getType() )

--- a/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
@@ -38,6 +38,10 @@ public class MavenVersionComparator extends AbstractVersionComparator
      */
     public int compare( ArtifactVersion o1, ArtifactVersion o2 )
     {
+        if ( o1 instanceof BoundArtifactVersion )
+        {
+            return o1.compareTo( o2 );
+        }
         return new ComparableVersion( o1.toString() ).compareTo( new ComparableVersion( o2.toString() ) );
     }
 

--- a/src/main/java/org/codehaus/mojo/versions/ordering/VersionComparator.java
+++ b/src/main/java/org/codehaus/mojo/versions/ordering/VersionComparator.java
@@ -20,9 +20,14 @@ package org.codehaus.mojo.versions.ordering;
  */
 
 import java.util.Comparator;
+import java.util.Optional;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.Restriction;
 import org.codehaus.mojo.versions.api.Segment;
+
+import static org.codehaus.mojo.versions.api.Segment.MAJOR;
+import static org.codehaus.mojo.versions.api.Segment.SUBINCREMENTAL;
 
 /**
  * A rule for comparing and manipulating versions.
@@ -49,4 +54,30 @@ public interface VersionComparator
      * @throws InvalidSegmentException if {@code segment} ∉ [0, segmentCount)
      */
     ArtifactVersion incrementSegment( ArtifactVersion artifactVersion, Segment segment ) throws InvalidSegmentException;
+
+    /**
+     * <p>Returns a {@linkplain Restriction} object for computing version <em>upgrades</em>
+     * with the given segment allowing updates, with all more major segments locked in place.</p>
+     * <p>The resulting restriction could be thought of as one
+     * retaining the versions on positions up to the held position,
+     * the position right after the position held in place will be incremented by one,
+     * and on all positions which are more minor than that, the range would contain -&infin;
+     * for the bottom bound and +&infin; for the above bound.</p>
+     * <p>This will allow matching the required versions while not matching versions which are considered
+     * inferior than the zeroth version, i.e. versions with a qualifier.</p>
+     *
+     * @param currentVersion The current version.
+     * @param scope most major segment where updates are allowed Optional.empty() for no restriction
+     * @return {@linkplain Restriction} object based on the arguments
+     */
+    default Restriction restrictionFor( ArtifactVersion currentVersion, Optional<Segment> scope )
+            throws InvalidSegmentException
+    {
+        ArtifactVersion nextVersion = scope.isPresent() && scope.get().isMajorTo( SUBINCREMENTAL )
+                ? incrementSegment( currentVersion, scope.get() )
+                : currentVersion;
+        return new Restriction( nextVersion, nextVersion != currentVersion, scope.filter( MAJOR::isMajorTo )
+                .map( s -> (ArtifactVersion) new BoundArtifactVersion( currentVersion, s ) ).orElse( null ),
+                false );
+    }
 }

--- a/src/site/apt/examples/advancing-dependency-versions.apt.vm
+++ b/src/site/apt/examples/advancing-dependency-versions.apt.vm
@@ -72,13 +72,13 @@ Goal Matrix
 
   The columns in the above goal matrix are as follows:
 
-  * <Modified Release dependencies> when scanning the <<<pom.xml>>> for depenendency to update, include those dependencies which 
+  * <Modified Release dependencies> when scanning the <<<pom.xml>>> for dependency to update, include those dependencies which
     are for release versions (i.e. non-SNAPSHOT versions).
 
-  * <Modified -SNAPSHOT dependencies> when scanning the <<<pom.xml>>> for depenendency to update, include those dependencies which 
+  * <Modified -SNAPSHOT dependencies> when scanning the <<<pom.xml>>> for dependency to update, include those dependencies which
     are for -SNAPSHOT versions.
 
-  * <Condsiders releases> when building the list of newer versions of a dependency, include release versions (i.e. non-SNAPSHOT
+  * <Considers releases> when building the list of newer versions of a dependency, include release versions (i.e. non-SNAPSHOT
     versions) in the list.
 
   * <Condsiders releases> when building the list of newer versions of a dependency, include -SNAPSHOT versions in the list.

--- a/src/site/apt/examples/display-plugin-updates.apt
+++ b/src/site/apt/examples/display-plugin-updates.apt
@@ -88,7 +88,7 @@ mvn versions:display-plugin-updates
 
   The plugin will also warn if you have not specified the versions of any plugins that you are using and tell you what
   version you are currently using.  Best practice in Maven is to always specify the plugin versions in order to
-  ensure that builds are reproducable.
+  ensure that builds are reproducible.
 
   For example the following <<<pom.xml>>>:
 

--- a/src/test/java/org/codehaus/mojo/versions/UseLatestReleasesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/UseLatestReleasesMojoTest.java
@@ -1,0 +1,106 @@
+package org.codehaus.mojo.versions;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.util.HashMap;
+
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.utils.DependencyBuilder;
+import org.codehaus.mojo.versions.utils.TestChangeRecorder;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static java.util.Collections.singletonList;
+import static org.apache.maven.artifact.Artifact.SCOPE_COMPILE;
+import static org.apache.maven.plugin.testing.ArtifactStubFactory.setVariableValueToObject;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockArtifactMetadataSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings( "deprecation" )
+public class UseLatestReleasesMojoTest
+{
+    private UseLatestReleasesMojo mojo;
+    private TestChangeRecorder changeRecorder;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        RepositorySystem repositorySystemMock = mock( RepositorySystem.class );
+        when( repositorySystemMock.createDependencyArtifact( any( Dependency.class ) ) ).thenAnswer( invocation ->
+        {
+            Dependency dependency = invocation.getArgument( 0 );
+            return new DefaultArtifact( dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(),
+                    dependency.getScope(), dependency.getType(),
+                    dependency.getClassifier() != null ? dependency.getClassifier() : "default", null );
+        } );
+
+        ArtifactMetadataSource artifactMetadataSourceMock = mockArtifactMetadataSource( new HashMap<String, String[]>()
+        {{
+            put( "dependency-artifact", new String[] {"0.9.0", "1.0.0-beta"} );
+        }} );
+
+        mojo = new UseLatestReleasesMojo( repositorySystemMock,
+                null,
+                artifactMetadataSourceMock,
+                null,
+                null )
+        {{
+            MavenProject project = new MavenProject()
+            {{
+                setModel( new Model()
+                {{
+                    setGroupId( "default-group" );
+                    setArtifactId( "project-artifact" );
+                    setVersion( "1.0.0-SNAPSHOT" );
+
+                    setDependencies( singletonList(
+                            DependencyBuilder.newBuilder()
+                                    .withGroupId( "default-group" )
+                                    .withArtifactId( "dependency-artifact" )
+                                    .withVersion( "0.9.0" )
+                                    .withScope( SCOPE_COMPILE )
+                                    .withType( "jar" )
+                                    .withClassifier( "default" )
+                                    .build() ) );
+                }} );
+            }};
+            setProject( project );
+
+            changeRecorder = new TestChangeRecorder();
+            setVariableValueToObject( this, "changeRecorder", changeRecorder );
+        }};
+    }
+
+    @Test
+    public void testDontUpgradeToBeta()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException
+    {
+        setVariableValueToObject( mojo, "processDependencies", true );
+        setVariableValueToObject( mojo, "allowSnapshots", false );
+        setVariableValueToObject( mojo, "allowMajorUpdates", false );
+        setVariableValueToObject( mojo, "allowMinorUpdates", true );
+        setVariableValueToObject( mojo, "allowIncrementalUpdates", false );
+
+        try ( MockedStatic<PomHelper> pomHelper = mockStatic( PomHelper.class ) )
+        {
+            pomHelper.when( () -> PomHelper.setDependencyVersion( any(), any(), any(), any(), any(), any() ) )
+                    .thenReturn( true );
+            mojo.update( null );
+        }
+        assertThat( changeRecorder.getChanges(), Matchers.empty() );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/versions/api/ArtifactVersionsTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/api/ArtifactVersionsTest.java
@@ -31,10 +31,14 @@ import org.codehaus.mojo.versions.ordering.MercuryVersionComparator;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import static java.util.Optional.of;
+import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
+import static org.codehaus.mojo.versions.api.Segment.SUBINCREMENTAL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 public class ArtifactVersionsTest
 {
@@ -104,5 +108,22 @@ public class ArtifactVersionsTest
             artifactVersions[i] = new DefaultArtifactVersion( versions[i] );
         }
         return artifactVersions;
+    }
+
+    @Test
+    public void testReportLabels()
+    {
+        ArtifactVersion[] versions = versions( "1.0.1", "1.0", "1.1.0-2", "1.1.1", "1.1.1-2", "1.1.2",
+                "1.1.2-SNAPSHOT", "1.1.3", "1.1", "1.1-SNAPSHOT", "1.2.1", "1.2.2", "1.2", "1.3",
+                "1.9.1-SNAPSHOT", "2.0", "2.1.1-SNAPSHOT", "2.1", "3.0", "3.1.1-SNAPSHOT",
+                "3.1.5-SNAPSHOT", "3.4.0-SNAPSHOT" );
+        ArtifactVersions instance =
+                new ArtifactVersions( new DefaultArtifact( "default-group", "dummy-api",
+                        "1.1", "foo", "bar",
+                        "jar", null ),
+                        Arrays.asList( versions ), new MavenVersionComparator() );
+
+        assertThat( instance.getNewestUpdate( of( SUBINCREMENTAL ) ).toString(), is( "1.1.0-2" ) );
+        assertThat( instance.getOldestUpdate( of( INCREMENTAL ) ).toString(), is( "1.1.1" ) );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/MavenVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/MavenVersionComparatorTest.java
@@ -19,14 +19,19 @@ package org.codehaus.mojo.versions.ordering;
  * under the License.
  */
 
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.codehaus.mojo.versions.api.Segment;
 import org.junit.Test;
 
+import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
 import static org.codehaus.mojo.versions.api.Segment.MAJOR;
 import static org.codehaus.mojo.versions.api.Segment.MINOR;
 import static org.codehaus.mojo.versions.api.Segment.SUBINCREMENTAL;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.Is.is;
 
 public class MavenVersionComparatorTest
 {
@@ -36,12 +41,12 @@ public class MavenVersionComparatorTest
     public void testSegmentCounting()
         throws Exception
     {
-        assertEquals( 3, instance.getSegmentCount( new DefaultArtifactVersion( "5" ) ) );
-        assertEquals( 3, instance.getSegmentCount( new DefaultArtifactVersion( "5.0" ) ) );
-        assertEquals( 4, instance.getSegmentCount( new DefaultArtifactVersion( "5-0" ) ) );
-        assertEquals( 1, instance.getSegmentCount( new DefaultArtifactVersion( "5.3.a" ) ) );
-        assertEquals( 1, instance.getSegmentCount( new DefaultArtifactVersion( "5.0.a.1.4.5" ) ) );
-        assertEquals( 3, instance.getSegmentCount( new DefaultArtifactVersion( "" ) ) );
+        assertThat( 3, is( instance.getSegmentCount( new DefaultArtifactVersion( "5" ) ) ) );
+        assertThat( 3, is( instance.getSegmentCount( new DefaultArtifactVersion( "5.0" ) ) ) );
+        assertThat( 4, is( instance.getSegmentCount( new DefaultArtifactVersion( "5-0" ) ) ) );
+        assertThat( 1, is( instance.getSegmentCount( new DefaultArtifactVersion( "5.3.a" ) ) ) );
+        assertThat( 1, is( instance.getSegmentCount( new DefaultArtifactVersion( "5.0.a.1.4.5" ) ) ) );
+        assertThat( 3, is( instance.getSegmentCount( new DefaultArtifactVersion( "" ) ) ) );
     }
 
     @Test
@@ -55,15 +60,48 @@ public class MavenVersionComparatorTest
         assertIncrement( "5.alpha-1.2", "5.alpha-1.1", MAJOR );
         assertIncrement( "5.alpha-1.ba", "5.alpha-1.az", MAJOR );
         assertIncrement( "5.alpha-wins.2", "5.alpha-wins.1", MAJOR );
-        assertIncrement( "1.0-alpha-3", "1.0-alpha-2-SNAPSHOT", SUBINCREMENTAL );
-        assertIncrement( "1.0-alpha-90", "1.0-alpha-9-SNAPSHOT", SUBINCREMENTAL );
-        assertIncrement( "1.0-za", "1.0-z-SNAPSHOT", SUBINCREMENTAL );
-        assertIncrement( "1.0-z90", "1.0-z9-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-alpha-3-SNAPSHOT", "1.0-alpha-2-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-alpha-90-SNAPSHOT", "1.0-alpha-9-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-za-SNAPSHOT", "1.0-z-SNAPSHOT", SUBINCREMENTAL );
+        assertIncrement( "1.0-z90-SNAPSHOT", "1.0-z9-SNAPSHOT", SUBINCREMENTAL );
     }
 
     private void assertIncrement( String expected, String initial, Segment segment ) throws InvalidSegmentException
     {
-        assertEquals( expected + "-SNAPSHOT",
-                      instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );
+        assertThat( instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString(),
+                is( expected ) );
+    }
+
+    @Test
+    public void testUpperBoundaryCustom()
+    {
+        assertThat( instance.compare( new BoundArtifactVersion( new DefaultArtifactVersion( "1.2.3" ),
+                INCREMENTAL ), new DefaultArtifactVersion( "1.2.3-ANDRZEJ" ) ), greaterThan( 0 ) );
+    }
+
+    @Test
+    public void testUpperBoundaryRelease()
+    {
+        assertThat( instance.compare( new BoundArtifactVersion( new DefaultArtifactVersion( "1.1.0" ),
+                INCREMENTAL ), new DefaultArtifactVersion( "1.1.0" ) ), greaterThan( 0 ) );
+    }
+
+    @Test
+    public void testUpperBoundarySnapshot()
+    {
+        assertThat( instance.compare( new BoundArtifactVersion( new DefaultArtifactVersion( "1.1.0" ),
+                INCREMENTAL ), new DefaultArtifactVersion( "1.1.0-SNAPSHOT" ) ), greaterThan( 0 ) );
+    }
+
+    @Test
+    public void testScopeLessThanNumSegmentsUpper()
+    {
+        ArtifactVersion artifactVersion = new BoundArtifactVersion( new DefaultArtifactVersion( "1.1" ),
+                SUBINCREMENTAL );
+        assertThat( artifactVersion.compareTo( new DefaultArtifactVersion( "1.0.1" ) ), greaterThan( 0 ) );
+        assertThat( artifactVersion.compareTo( new DefaultArtifactVersion( "1.1-SNAPSHOT" ) ), greaterThan( 0 ) );
+        assertThat( artifactVersion.compareTo( new DefaultArtifactVersion( "1.1" ) ), greaterThan( 0 ) );
+        assertThat( artifactVersion.compareTo( new DefaultArtifactVersion( "1.1.0-2" ) ), greaterThan( 0 ) );
+        assertThat( artifactVersion.compareTo( new DefaultArtifactVersion( "1.1.1-2" ) ), lessThan( 0 ) );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparatorTest.java
@@ -20,7 +20,6 @@ package org.codehaus.mojo.versions.ordering;
  */
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.codehaus.mojo.versions.api.Segment;
 import org.junit.Test;
 
 import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
@@ -46,19 +45,21 @@ public class MercuryVersionComparatorTest
     @Test
     public void testSegmentIncrementing() throws Exception
     {
-        assertIncrement( "6", "5", MAJOR );
-        assertIncrement( "6.0", "5.0", MAJOR );
-        assertIncrement( "5.1", "5.0", MINOR );
-        assertIncrement( "5.1.0", "5.0.1", MINOR );
-        assertIncrement( "5.beta.0", "5.alpha.1", MINOR );
-        assertIncrement( "5.beta-0.0", "5.alpha-1.1", MINOR );
-        assertIncrement( "5.alpha-2.0", "5.alpha-1.1", INCREMENTAL );
-        assertIncrement( "5.beta-0.0", "5.alpha-wins.1", MINOR );
-    }
-
-    private void assertIncrement( String expected, String initial, Segment segment ) throws InvalidSegmentException
-    {
-        assertEquals( expected + "-SNAPSHOT",
-                      instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );
+        assertEquals( new DefaultArtifactVersion( "6" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5" ), MAJOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "6.0" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MAJOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.1" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.1.0" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.0.1" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.beta.0" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha.1" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.beta-0.0" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.alpha-2.0" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), INCREMENTAL ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.beta-0.0" ).toString(),
+                instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-wins.1" ), MINOR ).toString() );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/ordering/NumericVersionComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/ordering/NumericVersionComparatorTest.java
@@ -20,7 +20,6 @@ package org.codehaus.mojo.versions.ordering;
  */
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.codehaus.mojo.versions.api.Segment;
 import org.junit.Test;
 
 import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
@@ -106,19 +105,22 @@ public class NumericVersionComparatorTest
     @Test
     public void testSegmentIncrementing() throws Exception
     {
-        assertIncrement( "6", "5", MAJOR );
-        assertIncrement( "6.0", "5.0", MAJOR );
-        assertIncrement( "5.1", "5.0", MINOR );
-        assertIncrement( "5.1.0", "5.0.1", MINOR );
-        assertIncrement( "5.beta.0", "5.alpha.1", MINOR );
-        assertIncrement( "5.alpha-2.0", "5.alpha-1.1", MINOR );
-        assertIncrement( "5.alpha-1.2", "5.alpha-1.1", INCREMENTAL );
-        assertIncrement( "5.beta.0", "5.alpha-wins.1", MINOR );
-    }
-
-    private void assertIncrement( String expected, String initial, Segment segment ) throws InvalidSegmentException
-    {
-        assertEquals( expected + "-SNAPSHOT",
-                      instance.incrementSegment( new DefaultArtifactVersion( initial ), segment ).toString() );
+        assertEquals( new DefaultArtifactVersion( "6" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5" ), MAJOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "6.0" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MAJOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.1" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.0" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.1.0" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.0.1" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.beta.0" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha.1" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.alpha-2.0" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), MINOR ).toString() );
+        assertEquals( new DefaultArtifactVersion( "5.alpha-1.2" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-1.1" ), INCREMENTAL )
+                              .toString() );
+        assertEquals( new DefaultArtifactVersion( "5.beta.0" ).toString(),
+                      instance.incrementSegment( new DefaultArtifactVersion( "5.alpha-wins.1" ), MINOR ).toString() );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/utils/MockUtils.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/MockUtils.java
@@ -32,6 +32,7 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.doxia.tools.SiteTool;
 import org.apache.maven.doxia.tools.SiteToolException;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.testing.stubs.DefaultArtifactHandlerStub;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
@@ -124,7 +125,7 @@ public class MockUtils
                 Dependency dependency = invocation.getArgument( 0 );
                 return new DefaultArtifact( dependency.getGroupId(), dependency.getArtifactId(),
                                             dependency.getVersion(), dependency.getScope(), dependency.getType(),
-                                            dependency.getClassifier(), null );
+                                            dependency.getClassifier(), new DefaultArtifactHandlerStub( "default" ) );
             } );
         return repositorySystem;
     }


### PR DESCRIPTION
Instead of using the next version for range calculation when considering version upgrades, I've devised a sort of a bounded artifact version where we use the concept of "infinity" on a given segment position to match all possible upper versions on the position, but nothing from the more major segment. So, 2.0.0-beta or similar won't be matched anymore when considering minor updates of the 1.x.x branch.

Tests added as unit tests; in particular, two for testing the case explained in #454 in `DisplayDependencyUpdatesMojoTest`

Some minor refactoring and typo corrections.