### PR TITLE
#729: Ignoring the flipper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,16 @@
           <pomIncludes>
             <pomInclude>*/pom.xml</pomInclude>
           </pomIncludes>
+          <pomExcludes>
+            <!--
+              ! This test is not really intended as part of regular integration test suite
+              ! as it highly depends on the minute conditions of the build cluster,
+              ! internet connection speed (since retrieval times are included in the timeout)
+              ! or individual machine where it's being tested.
+              ! Not deleting as it might be helpful with assessing performance measurements.
+            -->
+            <pomExclude>it-property-updates-report-002-slow/*</pomExclude>
+          </pomExcludes>
           <postBuildHookScript>verify</postBuildHookScript>
           <filterProperties>
             <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>


### PR DESCRIPTION
This test should be used for profiling and not as part of integration testing. Caching rule resolution is a good start, but the actual performance depends on the machine and conditions of the cluster, but tests should not really depend on the volatile cluster state.