### PR TITLE
Caching update information in reports to increase performance

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersionsCache.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersionsCache.java
@@ -1,0 +1,66 @@
+package org.codehaus.mojo.versions.api;
+
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Utility providing a cached {@link ArtifactVersions#getOldestUpdate(Optional)} API
+ */
+public class ArtifactVersionsCache
+{
+    private BiFunction<AbstractVersionDetails, Optional<Segment>, ?> cachedFunction;
+
+    private Map<Pair<? extends AbstractVersionDetails, Optional<Segment>>, Object> updateCache = new HashMap<>();
+
+    /**
+     * Constructs a new instance given the concrete function for obtaining the details
+     *
+     * @param cachedFunction reference to the function computing the required information
+     */
+    public ArtifactVersionsCache( BiFunction<AbstractVersionDetails, Optional<Segment>, ?>
+                                          cachedFunction )
+    {
+        this.cachedFunction = cachedFunction;
+    }
+
+    /**
+     * Returns the required information for the given {@link ArtifactVersions} object and the given update scope.
+     * If the information is already present in cache, the cached version is returned. Otherwise,
+     * the {@code artifactVersions} object is queried and the response is cached.
+     *
+     * @param artifactVersions {@linkplain ArtifactVersions} object referring to the given dependency
+     * @param updateScope      update scope
+     * @return last retrieved update information
+     */
+    @SuppressWarnings( "unchecked" )
+    public <V extends AbstractVersionDetails, R> R get( V artifactVersions,
+                                                        Optional<Segment> updateScope )
+    {
+        return (R) updateCache.computeIfAbsent( Pair.of( artifactVersions, updateScope ),
+                pair -> cachedFunction.apply( pair.getLeft(), pair.getRight() ) );
+    }
+}

--- a/src/main/java/org/codehaus/mojo/versions/reporting/AbstractVersionsReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/reporting/AbstractVersionsReportRenderer.java
@@ -28,7 +28,9 @@ import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.model.Dependency;
+import org.codehaus.mojo.versions.api.AbstractVersionDetails;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.api.ArtifactVersionsCache;
 import org.codehaus.mojo.versions.api.ReportRenderer;
 import org.codehaus.plexus.i18n.I18N;
 
@@ -55,6 +57,12 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
      * @since 2.13.0
      */
     protected T model;
+
+    protected ArtifactVersionsCache oldestUpdateCache
+            = new ArtifactVersionsCache( AbstractVersionDetails::getOldestUpdate );
+
+    protected ArtifactVersionsCache allUpdatesCache
+            = new ArtifactVersionsCache( AbstractVersionDetails::getAllUpdates );
 
     /**
      * Constructor to be called by the dependency injection framework
@@ -319,26 +327,26 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
         sink.text( getText( "report.status" ) );
         sink.tableHeaderCell_();
         sink.tableCell( cellAttributes );
-        ArtifactVersion[] versions = details.getAllUpdates( empty() );
-        if ( details.getOldestUpdate( of( SUBINCREMENTAL ) ) != null )
+        ArtifactVersion[] versions = allUpdatesCache.get( details, empty() );
+        if ( oldestUpdateCache.get( details, of( SUBINCREMENTAL ) ) != null )
         {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text( getText( "report.otherUpdatesAvailable" ) );
         }
-        else if ( details.getOldestUpdate( of( INCREMENTAL ) ) != null )
+        else if ( oldestUpdateCache.get( details, of( INCREMENTAL ) ) != null )
         {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text( getText( "report.incrementalUpdatesAvailable" ) );
         }
-        else if ( details.getOldestUpdate( of( MINOR ) ) != null )
+        else if ( oldestUpdateCache.get( details, of( MINOR ) ) != null )
         {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text( getText( "report.minorUpdatesAvailable" ) );
         }
-        else if ( details.getOldestUpdate( of( MAJOR ) ) != null )
+        else if ( oldestUpdateCache.get( details, of( MAJOR ) ) != null )
         {
             renderWarningIcon();
             sink.nonBreakingSpace();

--- a/src/main/java/org/codehaus/mojo/versions/reporting/DependencyUpdatesReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/reporting/DependencyUpdatesReportRenderer.java
@@ -95,19 +95,19 @@ public class DependencyUpdatesReportRenderer<K extends DependencyUpdatesModel> e
         OverviewStats stats = new OverviewStats();
         model.getAllUpdates().values().forEach( details ->
         {
-            if ( details.getOldestUpdate( of( SUBINCREMENTAL ) ) != null )
+            if ( oldestUpdateCache.get( details, of( SUBINCREMENTAL ) ) != null )
             {
                 stats.incrementAny();
             }
-            else if ( details.getOldestUpdate( of( INCREMENTAL ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( INCREMENTAL ) ) != null )
             {
                 stats.incrementIncremental();
             }
-            else if ( details.getOldestUpdate( of( MINOR ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( MINOR ) ) != null )
             {
                 stats.incrementMinor();
             }
-            else if ( details.getOldestUpdate( of( MAJOR ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( MAJOR ) ) != null )
             {
                 stats.incrementMajor();
             }

--- a/src/main/java/org/codehaus/mojo/versions/reporting/PluginUpdatesReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/reporting/PluginUpdatesReportRenderer.java
@@ -30,7 +30,9 @@ import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.model.Dependency;
 import org.codehaus.mojo.versions.PluginUpdatesDetails;
+import org.codehaus.mojo.versions.api.AbstractVersionDetails;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.api.ArtifactVersionsCache;
 import org.codehaus.mojo.versions.reporting.model.PluginUpdatesModel;
 import org.codehaus.plexus.i18n.I18N;
 
@@ -46,6 +48,9 @@ import static org.codehaus.mojo.versions.api.Segment.SUBINCREMENTAL;
  */
 public class PluginUpdatesReportRenderer extends AbstractVersionsReportRenderer<PluginUpdatesModel>
 {
+    protected ArtifactVersionsCache newestUpdateCache
+            = new ArtifactVersionsCache( AbstractVersionDetails::getNewestUpdate );
+
     public PluginUpdatesReportRenderer( I18N i18n, Sink sink, Locale locale, String bundleName,
                                         PluginUpdatesModel model )
     {
@@ -149,19 +154,19 @@ public class PluginUpdatesReportRenderer extends AbstractVersionsReportRenderer<
         PluginOverviewStats stats = new PluginOverviewStats();
         model.getAllUpdates().values().forEach( details ->
         {
-            if ( details.getOldestUpdate( of( SUBINCREMENTAL ) ) != null )
+            if ( oldestUpdateCache.get( details, of( SUBINCREMENTAL ) ) != null )
             {
                 stats.incrementAny();
             }
-            else if ( details.getOldestUpdate( of( INCREMENTAL ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( INCREMENTAL ) ) != null )
             {
                 stats.incrementIncremental();
             }
-            else if ( details.getOldestUpdate( of( MINOR ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( MINOR ) ) != null )
             {
                 stats.incrementMinor();
             }
-            else if ( details.getOldestUpdate( of( MAJOR ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( MAJOR ) ) != null )
             {
                 stats.incrementMajor();
             }
@@ -228,37 +233,37 @@ public class PluginUpdatesReportRenderer extends AbstractVersionsReportRenderer<
         sink.tableCell_();
 
         sink.tableCell();
-        if ( details.getNewestUpdate( of( SUBINCREMENTAL ) ) != null )
+        if ( newestUpdateCache.get( details, of( SUBINCREMENTAL ) ) != null )
         {
             safeBold();
-            sink.text( details.getNewestUpdate( of( SUBINCREMENTAL ) ).toString() );
+            sink.text( newestUpdateCache.get( details, of( SUBINCREMENTAL ) ).toString() );
             safeBold_();
         }
         sink.tableCell_();
 
         sink.tableCell();
-        if ( details.getNewestUpdate( of( INCREMENTAL ) ) != null )
+        if ( newestUpdateCache.get( details, of( INCREMENTAL ) ) != null )
         {
             safeBold();
-            sink.text( details.getNewestUpdate( of( INCREMENTAL ) ).toString() );
+            sink.text( newestUpdateCache.get( details, of( INCREMENTAL ) ).toString() );
             safeBold_();
         }
         sink.tableCell_();
 
         sink.tableCell();
-        if ( details.getNewestUpdate( of( MINOR ) ) != null )
+        if ( newestUpdateCache.get( details, of( MINOR ) ) != null )
         {
             safeBold();
-            sink.text( details.getNewestUpdate( of( MINOR ) ).toString() );
+            sink.text( newestUpdateCache.get( details, of( MINOR ) ).toString() );
             safeBold_();
         }
         sink.tableCell_();
 
         sink.tableCell();
-        if ( details.getNewestUpdate( of( MAJOR ) ) != null )
+        if ( newestUpdateCache.get( details, of( MAJOR ) ) != null )
         {
             safeBold();
-            sink.text( details.getNewestUpdate( of( MAJOR ) ).toString() );
+            sink.text( newestUpdateCache.get( details, of( MAJOR ) ).toString() );
             safeBold_();
         }
         sink.tableCell_();

--- a/src/main/java/org/codehaus/mojo/versions/reporting/PropertyUpdatesReportRenderer.java
+++ b/src/main/java/org/codehaus/mojo/versions/reporting/PropertyUpdatesReportRenderer.java
@@ -394,19 +394,19 @@ public class PropertyUpdatesReportRenderer extends AbstractVersionsReportRendere
         OverviewStats stats = new OverviewStats();
         model.getAllUpdates().values().forEach( details ->
         {
-            if ( details.getOldestUpdate( of( SUBINCREMENTAL ) ) != null )
+            if ( oldestUpdateCache.get( details, of( SUBINCREMENTAL ) ) != null )
             {
                 stats.incrementAny();
             }
-            else if ( details.getOldestUpdate( of( INCREMENTAL ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( INCREMENTAL ) ) != null )
             {
                 stats.incrementIncremental();
             }
-            else if ( details.getOldestUpdate( of( MINOR ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( MINOR ) ) != null )
             {
                 stats.incrementMinor();
             }
-            else if ( details.getOldestUpdate( of( MAJOR ) ) != null )
+            else if ( oldestUpdateCache.get( details, of( MAJOR ) ) != null )
             {
                 stats.incrementMajor();
             }


### PR DESCRIPTION
Noticed some duplication of calls to `AbstractVersionDetails::getOldestUpdate` and similar: e.g. the same information is retrieved first during the rendering of the "Overview" section to gather aggregate information, then the call is repeated to render update details.