### PR TITLE
#367: Include parent projects in property resolution

### DIFF
--- a/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
@@ -1,0 +1,88 @@
+package org.codehaus.mojo.versions;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.codehaus.mojo.versions.utils.MockUtils;
+import org.codehaus.mojo.versions.utils.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+
+/**
+ * Unit tests for {@link DisplayPropertyUpdatesMojo}
+ */
+public class DisplayPropertyUpdatesMojoTest extends AbstractMojoTestCase
+{
+    @Rule
+    public MojoRule mojoRule = new MojoRule( this );
+
+    private Path tempDir;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        super.setUp();
+        tempDir = TestUtils.createTempDir( "display-property-updates" );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        try
+        {
+            TestUtils.tearDownTempDir( tempDir );
+        }
+        finally
+        {
+            super.tearDown();
+        }
+    }
+
+    @Test
+    public void testPropertiesFromParent() throws Exception
+    {
+        Path tempFile = Files.createTempFile( tempDir, "output", "" );
+
+        TestUtils.copyDir( Paths.get( "src/test/resources/org/codehaus/mojo/display-property-updates/issue-367" ),
+                tempDir );
+        DisplayPropertyUpdatesMojo mojo =
+                (DisplayPropertyUpdatesMojo) mojoRule.lookupConfiguredMojo( tempDir.resolve( "child" ).toFile(),
+                        "display-property-updates" );
+        mojo.outputEncoding = UTF_8;
+        mojo.outputFile = tempFile.toFile();
+        mojo.setPluginContext( new HashMap<>() );
+        mojo.artifactMetadataSource = MockUtils.mockArtifactMetadataSource();
+        mojo.execute();
+
+        assertThat( String.join( "", Files.readAllLines( tempFile ) ),
+                matchesPattern( ".*\\$\\{ver} \\.* 1\\.0\\.0 -> 2\\.0\\.0.*" ) );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/versions/utils/TestUtils.java
+++ b/src/test/java/org/codehaus/mojo/versions/utils/TestUtils.java
@@ -26,6 +26,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.apache.commons.text.CaseUtils.toCamelCase;
 
 /**
@@ -35,6 +36,7 @@ public class TestUtils
 {
     /**
      * Creates a temporary directory with the given name
+     *
      * @param name name of the directory to create
      * @return {@linkplain Path} object pointing to the directory
      * @throws IOException should the I/O operation fail
@@ -46,6 +48,7 @@ public class TestUtils
 
     /**
      * Deletes the given directory together with all its contents
+     *
      * @param dir directory to delete
      * @throws IOException should an I/O operation fail
      */
@@ -70,5 +73,35 @@ public class TestUtils
                 }
             } );
         }
+    }
+
+    /**
+     * Copies the {@code src} directory to {@code dst} recursively,
+     * creating the missing directories if necessary
+     *
+     * @param src source directory path
+     * @param dst destination directory path
+     * @throws IOException should an I/O error occur
+     */
+    public static void copyDir( Path src, Path dst ) throws IOException
+    {
+        Files.walkFileTree( src, new SimpleFileVisitor<Path>()
+        {
+            @Override
+            public FileVisitResult preVisitDirectory( Path dir, BasicFileAttributes attrs )
+                    throws IOException
+            {
+                Files.createDirectories( dst.resolve( src.relativize( dir ) ) );
+                return CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile( Path file, BasicFileAttributes attrs )
+                    throws IOException
+            {
+                Files.copy( file, dst.resolve( src.relativize( file ) ), REPLACE_EXISTING );
+                return CONTINUE;
+            }
+        } );
     }
 }

--- a/src/test/resources/org/codehaus/mojo/display-property-updates/issue-367/child/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/display-property-updates/issue-367/child/pom.xml
@@ -1,0 +1,20 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>child</artifactId>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>default-group</groupId>
+                <artifactId>artifactA</artifactId>
+                <version>${ver}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/src/test/resources/org/codehaus/mojo/display-property-updates/issue-367/pom.xml
+++ b/src/test/resources/org/codehaus/mojo/display-property-updates/issue-367/pom.xml
@@ -1,0 +1,11 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <ver>1.0.0</ver>
+    </properties>
+</project>


### PR DESCRIPTION
Includes parent projects in property resolution for property updates. Instead of only considering the model of the current project, will also consult parent models to see if there are property definitions for properties defined in the current project.