### PR TITLE
Remove redundant logs in info level

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/utils/SegmentUtils.java
+++ b/src/main/java/org/codehaus/mojo/versions/utils/SegmentUtils.java
@@ -84,9 +84,9 @@ public class SegmentUtils
                     : allowIncrementalUpdates
                         ? of( MINOR )
                         : of( INCREMENTAL );
-        if ( log != null && log.isInfoEnabled() )
+        if ( log != null && log.isDebugEnabled() )
         {
-            log.info(
+            log.debug(
                     unchangedSegment.map( s -> Segment.of( s.value() + 1 ).toString() )
                             .orElse( "ALL" ) + " version changes allowed" );
         }


### PR DESCRIPTION
When execute: `mvn versions:display-property-updates` I see output like:

```
[INFO] --- versions-maven-plugin:2.12.0:display-property-updates (default-cli) @ parent ---
[INFO] Major version changes allowed
[INFO] Major version changes allowed
[INFO] Major version changes allowed
....
[INFO] Major version changes allowed
[INFO] Major version changes allowed
[INFO] Major version changes allowed
[INFO] 
[INFO] The following version properties are referencing the newest available version:
[INFO]   ${build-helper-maven-plugin.version} .......................... 3.3.0
[INFO]   ${jacoco-maven-plugin.version} ................................ 0.8.8
....
```

The log `Major version changes allowed` is printed many times for each property without context.
I think it not give any useful information in info level.