### PR TITLE
Resolves #776: onlyUpgradable change the filter to versions where the current version is not the latest one

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojo.java
@@ -25,15 +25,18 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -202,8 +205,21 @@ public class DependencyUpdatesReportMojo extends AbstractVersionsReport<Dependen
 
             if ( onlyUpgradable )
             {
-                dependencyUpdates = filter( dependencyUpdates, e -> e.getVersions().length > 1 );
-                dependencyManagementUpdates = filter( dependencyManagementUpdates, e -> e.getVersions().length > 1 );
+                dependencyUpdates = filter( dependencyUpdates, e -> e.getVersions().length > 0 );
+                dependencyManagementUpdates = filter( dependencyManagementUpdates, e -> e.getVersions().length > 0 );
+            }
+
+            if ( getLog().isDebugEnabled() )
+            {
+                getLog().debug( "Dependency versions:" );
+                dependencyUpdates.forEach( ( key, value ) -> getLog().debug( key.toString() + ": "
+                        + Arrays.stream( value.getVersions() ).map( ArtifactVersion::toString )
+                        .collect( Collectors.joining( ", " ) ) ) );
+
+                getLog().debug( "Dependency management versions:" );
+                dependencyManagementUpdates.forEach( ( key, value ) -> getLog().debug( key.toString() + ": "
+                        + Arrays.stream( value.getVersions() ).map( ArtifactVersion::toString )
+                        .collect( Collectors.joining( ", " ) ) ) );
             }
 
             for ( String format : formats )

--- a/src/main/java/org/codehaus/mojo/versions/PluginUpdatesReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/PluginUpdatesReportMojo.java
@@ -163,10 +163,8 @@ public class PluginUpdatesReportMojo extends AbstractVersionsReport<PluginUpdate
 
             if ( onlyUpgradable )
             {
-                pluginUpdates =
-                        filter( pluginUpdates, plugin -> plugin.getVersions().length > 1 );
-                pluginManagementUpdates = filter( pluginManagementUpdates,
-                        plugin -> plugin.getVersions().length > 1 );
+                pluginUpdates = filter( pluginUpdates, p -> p.getVersions().length > 0 );
+                pluginManagementUpdates = filter( pluginManagementUpdates, p -> p.getVersions().length > 0 );
             }
 
             PluginUpdatesModel model = new PluginUpdatesModel( pluginUpdates, pluginManagementUpdates );

--- a/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -340,6 +340,12 @@ public abstract class AbstractVersionDetails
     }
 
     @Override
+    public final ArtifactVersion[] getAllUpdates()
+    {
+        return getAllUpdates( (VersionRange) null, isIncludeSnapshots() );
+    }
+
+    @Override
     public final ArtifactVersion[] getAllUpdates( VersionRange versionRange )
     {
         return getAllUpdates( versionRange, isIncludeSnapshots() );

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -349,6 +349,14 @@ public interface VersionDetails
             throws InvalidSegmentException;
 
     /**
+     * Returns the all versions newer than the specified current version
+     *
+     * @return the all versions after currentVersion
+     * @since 2.13.0
+     */
+    ArtifactVersion[] getAllUpdates();
+
+    /**
      * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param versionRange the version range to include.

--- a/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojoTest.java
@@ -149,6 +149,12 @@ public class DependencyUpdatesReportMojoTest
             return this;
         }
 
+        public TestDependencyUpdatesReportMojo withAllowSnapshots( boolean allowSnapshots )
+        {
+            this.allowSnapshots = allowSnapshots;
+            return this;
+        }
+
         private static RepositorySystem mockRepositorySystem()
         {
             RepositorySystem repositorySystem = mock( RepositorySystem.class );
@@ -183,13 +189,21 @@ public class DependencyUpdatesReportMojoTest
         SinkFactory sinkFactory = new Xhtml5SinkFactory();
         new TestDependencyUpdatesReportMojo()
             .withOnlyUpgradable( true )
+                .withArtifactMetadataSource( mockArtifactMetadataSource( new HashMap<String, String[]>()
+                {{
+                    put( "artifactA", new String[] { "1.0.0", "2.0.0" } );
+                    put( "artifactB", new String[] { "1.0.0" } );
+                    put( "artifactC", new String[] { "1.0.0", "2.0.0" } );
+                }} ) )
             .withDependencies(
-                dependencyOf( "artifactA" ), dependencyOf( "artifactB" ),
-                dependencyOf( "artifactC" ) )
+                dependencyOf( "artifactA", "1.0.0" ),
+                dependencyOf( "artifactB", "1.0.0" ),
+                dependencyOf( "artifactC", "2.0.0" ) )
             .generate( sinkFactory.createSink( os ), sinkFactory, Locale.getDefault() );
 
         String output = os.toString();
-        assertThat( output, allOf( containsString( "artifactA" ), containsString( "artifactB" ) ) );
+        assertThat( output, containsString( "artifactA" ) );
+        assertThat( output, not( containsString( "artifactB" ) ) );
         assertThat( output, not( containsString( "artifactC" ) ) );
     }
 


### PR DESCRIPTION
Root cause of the issue: `VersionsHelper.lookupDependenciesUpdates` actually returns all dependency versions, and not just updates.

The problem manifested itself when the currently used version was the latest, but there were more versions reported (older than the current one).

This is now corrected, i.e. the method returns only updates, in contrast to `lookupArtifactVersions`.

`onlyUpgradableOnly` looks to work fine now. Updated the unit tests to test also for cases when the version used by an artifact is the latest version, but there are more available versions (older than the current one).

Removed some redundant classes implementing `Callable`, which could very easily be inlined which results in a much cleaner code.

Also, as a minor pedantic fix, corrected the "splitted" [sic] to "split" in one method name. 