### PR TITLE
Resolves #793: Added includeParent to DisplayPropertyUpdates and PropertyUpdatesReport

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
@@ -47,6 +47,7 @@ import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 
@@ -206,7 +207,8 @@ public class CompareDependenciesMojo
         if ( updatePropertyVersions )
         {
             Map<Property, PropertyVersions> versionProperties =
-                this.getHelper().getVersionPropertiesMap( getProject(), null, null, null, true );
+                    this.getHelper().getVersionPropertiesMap( VersionsHelper.VersionPropertiesMapRequest.builder()
+                            .withMavenProject( getProject() ).build() );
             List<String> diff = updatePropertyVersions( pom, versionProperties, remoteDepsMap );
             propertyDiffs.addAll( diff );
         }

--- a/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -42,6 +42,7 @@ import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.api.Segment;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.SegmentUtils;
@@ -128,6 +129,14 @@ public class DisplayPropertyUpdatesMojo
     @Parameter( property = "allowIncrementalUpdates", defaultValue = "true" )
     private boolean allowIncrementalUpdates;
 
+    /**
+     * <p>Whether to include property updates from parent.</p>
+     *
+     * @since 2.14.0
+     */
+    @Parameter( property = "includeParent", defaultValue = "true" )
+    protected boolean includeParent = true;
+
     // -------------------------- STATIC METHODS --------------------------
 
     // -------------------------- OTHER METHODS --------------------------
@@ -150,8 +159,14 @@ public class DisplayPropertyUpdatesMojo
         List<String> updates = new ArrayList<>();
 
         Map<Property, PropertyVersions> propertyVersions =
-            this.getHelper().getVersionPropertiesMap( getProject(), properties, includeProperties, excludeProperties,
-                                                      autoLinkItems );
+                this.getHelper().getVersionPropertiesMap( VersionsHelper.VersionPropertiesMapRequest.builder()
+                        .withMavenProject( getProject() )
+                        .withPropertyDefinitions( properties )
+                        .withIncludeProperties( includeProperties )
+                        .withExcludeProperties( excludeProperties )
+                        .withIncludeParent( includeParent )
+                        .withAutoLinkItems( autoLinkItems )
+                        .build() );
         for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
         {
             Property property = entry.getKey();

--- a/src/main/java/org/codehaus/mojo/versions/PropertyUpdatesReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/PropertyUpdatesReportMojo.java
@@ -36,6 +36,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PropertyVersions;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.reporting.ReportRendererFactory;
 import org.codehaus.mojo.versions.reporting.model.PropertyUpdatesModel;
 import org.codehaus.mojo.versions.utils.PropertyComparator;
@@ -84,6 +85,14 @@ public class PropertyUpdatesReportMojo extends AbstractVersionsReport<PropertyUp
     @Parameter( property = "autoLinkItems", defaultValue = "true" )
     private boolean autoLinkItems;
 
+    /**
+     * <p>Whether to include property updates from parent.</p>
+     *
+     * @since 2.14.0
+     */
+    @Parameter( property = "includeParent", defaultValue = "true" )
+    private boolean includeParent = true;
+
     @Inject
     protected PropertyUpdatesReportMojo( I18N i18n, RepositorySystem repositorySystem,
                                          ArtifactResolver artifactResolver,
@@ -120,8 +129,14 @@ public class PropertyUpdatesReportMojo extends AbstractVersionsReport<PropertyUp
         final Map<Property, PropertyVersions> updateSet = new TreeMap<>( PropertyComparator.INSTANCE );
         try
         {
-            updateSet.putAll( getHelper().getVersionPropertiesMap( getProject(), properties, includeProperties,
-                                                                   excludeProperties, autoLinkItems ) );
+            updateSet.putAll( getHelper().getVersionPropertiesMap( VersionsHelper.VersionPropertiesMapRequest.builder()
+                    .withMavenProject( getProject() )
+                    .withPropertyDefinitions( properties )
+                    .withIncludeProperties( includeProperties )
+                    .withExcludeProperties( excludeProperties )
+                    .withIncludeParent( includeParent )
+                    .withAutoLinkItems( autoLinkItems )
+                    .build() ) );
         }
         catch ( MojoExecutionException e )
         {

--- a/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -46,6 +46,7 @@ import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.api.Segment;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.SegmentUtils;
@@ -304,7 +305,11 @@ public class ResolveRangesMojo
     {
 
         Map<Property, PropertyVersions> propertyVersions =
-            this.getHelper().getVersionPropertiesMap( getProject(), null, includeProperties, excludeProperties, true );
+                this.getHelper().getVersionPropertiesMap( VersionsHelper.VersionPropertiesMapRequest.builder()
+                        .withMavenProject( getProject() )
+                        .withIncludeProperties( includeProperties )
+                        .withExcludeProperties( excludeProperties )
+                        .build() );
         for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
         {
             Property property = entry.getKey();

--- a/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -37,6 +37,7 @@ import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.PropertyVersions;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.PropertiesVersionsFileReader;
 
@@ -154,8 +155,12 @@ public class SetPropertyMojo
         throws MojoExecutionException, XMLStreamException
     {
         Map<Property, PropertyVersions> propertyVersions =
-            this.getHelper().getVersionPropertiesMap( getProject(), propertiesConfig, properties, "",
-                                                      autoLinkItems );
+                this.getHelper().getVersionPropertiesMap( VersionsHelper.VersionPropertiesMapRequest.builder()
+                        .withMavenProject( getProject() )
+                        .withPropertyDefinitions( propertiesConfig )
+                        .withIncludeProperties( properties )
+                        .withAutoLinkItems( autoLinkItems )
+                        .build() );
         for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
         {
             Property currentProperty = entry.getKey();

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.api.Segment;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
@@ -156,11 +157,14 @@ public class UpdatePropertiesMojo extends AbstractVersionsDependencyUpdaterMojo
     protected void update( ModifiedPomXMLEventReader pom )
         throws MojoExecutionException, MojoFailureException, XMLStreamException
     {
-        Map<Property, PropertyVersions> propertyVersions = this.getHelper().getVersionPropertiesMap( getProject(),
-                                                                                                     properties,
-                                                                                                     includeProperties,
-                                                                                                     excludeProperties,
-                                                                                                     autoLinkItems );
+        Map<Property, PropertyVersions> propertyVersions = getHelper().getVersionPropertiesMap(
+                VersionsHelper.VersionPropertiesMapRequest.builder()
+                        .withMavenProject( getProject() )
+                        .withPropertyDefinitions( properties )
+                        .withIncludeProperties( includeProperties )
+                        .withExcludeProperties( excludeProperties )
+                        .withAutoLinkItems( autoLinkItems )
+                        .build() );
         for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
         {
             Property property = entry.getKey();

--- a/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.api.Segment;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.SegmentUtils;
@@ -158,8 +159,13 @@ public class UpdatePropertyMojo
         Property propertyConfig = new Property( property );
         propertyConfig.setVersion( newVersion );
         Map<Property, PropertyVersions> propertyVersions =
-            this.getHelper().getVersionPropertiesMap( getProject(), new Property[] {propertyConfig}, property, "",
-                                                      autoLinkItems );
+            this.getHelper().getVersionPropertiesMap(
+                    VersionsHelper.VersionPropertiesMapRequest.builder()
+                            .withMavenProject( getProject() )
+                            .withPropertyDefinitions( new Property[] {propertyConfig} )
+                            .withIncludeProperties( property )
+                            .withAutoLinkItems( autoLinkItems )
+                            .build() );
         for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
         {
             Property property = entry.getKey();

--- a/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
@@ -221,19 +221,192 @@ public interface VersionsHelper
      * {@link org.codehaus.mojo.versions.Property} instances consisting of the properties defined in the project which
      * are associated with version information.
      *
-     * @param project The project.
-     * @param propertyDefinitions Any extra hints about properties.
-     * @param includeProperties A comma separated list of properties to include.
-     * @param excludeProperties A comma separated list of properties to exclude.
-     * @param autoLinkItems whether to automatically infer associations
+     * @param request {@link VersionPropertiesMapRequest} instance containing the arguments
      * @return a map of {@link org.codehaus.mojo.versions.api.PropertyVersions} values keyed by
      *         {@link org.codehaus.mojo.versions.Property} instances.
      * @throws MojoExecutionException if something goes wrong.
      */
-    Map<Property, PropertyVersions> getVersionPropertiesMap( MavenProject project, Property[] propertyDefinitions,
-                                                             String includeProperties, String excludeProperties,
-                                                             boolean autoLinkItems )
+    Map<Property, PropertyVersions> getVersionPropertiesMap( VersionPropertiesMapRequest request )
         throws MojoExecutionException;
+
+    /**
+     * Argument builder class for
+     * {@link VersionsHelper#getVersionPropertiesMap(VersionPropertiesMapRequest)}.
+     */
+    class VersionPropertiesMapRequest
+    {
+        private MavenProject mavenProject;
+        private Property[] propertyDefinitions;
+        private String includeProperties;
+        private String excludeProperties;
+        private boolean includeParent;
+        private boolean autoLinkItems;
+
+        /**
+         * Returns the {@link MavenProject} object
+         * @return {@link MavenProject} object
+         */
+        protected MavenProject getMavenProject()
+        {
+            return mavenProject;
+        }
+
+        /**
+         * Returns the {@link Property} array
+         * @return {@link Property} array
+         */
+        protected Property[] getPropertyDefinitions()
+        {
+            return propertyDefinitions;
+        }
+
+        /**
+         * Returns the value of {@link #includeProperties}
+         * @return value of {@link #includeProperties}
+         */
+        protected String getIncludeProperties()
+        {
+            return includeProperties;
+        }
+
+        /**
+         * Returns the value of {@link #excludeProperties}
+         * @return value of {@link #excludeProperties}
+         */
+        protected String getExcludeProperties()
+        {
+            return excludeProperties;
+        }
+
+        /**
+         * Returns the value of {@link #includeParent}.
+         * If not set, it is assumed to be {@code true}
+         *
+         * @return value of {@link #includeParent}
+         */
+        protected boolean isIncludeParent()
+        {
+            return includeParent;
+        }
+
+        /**
+         * Returns the value of {@link #autoLinkItems}
+         * If not set, it is assumed to be {@code true}
+         * @return value of {@link #autoLinkItems}
+         */
+        protected boolean isAutoLinkItems()
+        {
+            return autoLinkItems;
+        }
+
+        /**
+         * Returns a new {@link Builder} instance
+         * @return new {@link Builder} instance
+         */
+        public static Builder builder()
+        {
+            return new Builder();
+        }
+
+        /**
+         * Builder class for {@link VersionPropertiesMapRequest}
+         */
+        public static class Builder
+        {
+            private MavenProject mavenProject;
+            private Property[] propertyDefinitions;
+            private String includeProperties;
+            private String excludeProperties;
+            private Boolean includeParent;
+            private Boolean autoLinkItems;
+
+            private Builder()
+            {
+            }
+
+            /**
+             * Supplies the {@link MavenProject} instance
+             * @param mavenProject {@link MavenProject} instance
+             * @return {@link Builder} instance
+             */
+            public Builder withMavenProject( MavenProject mavenProject )
+            {
+                this.mavenProject = mavenProject;
+                return this;
+            }
+
+            /**
+             * Supplies the {@link MavenProject} instance
+             * @param propertyDefinitions array of property definitions
+             * @return {@link Builder} instance
+             */
+            public Builder withPropertyDefinitions( Property[] propertyDefinitions )
+            {
+                this.propertyDefinitions = propertyDefinitions;
+                return this;
+            }
+
+            /**
+             * Supplies the properties to include
+             * @param includeProperties comma-delimited properties to include
+             * @return {@link Builder} instance
+             */
+            public Builder withIncludeProperties( String includeProperties )
+            {
+                this.includeProperties = includeProperties;
+                return this;
+            }
+
+            /**
+             * Supplies the properties to exclude
+             * @param excludeProperties comma-delimited properties to exclude
+             * @return {@link Builder} instance
+             */
+            public Builder withExcludeProperties( String excludeProperties )
+            {
+                this.excludeProperties = excludeProperties;
+                return this;
+            }
+
+            /**
+             * Supplies the includeParent parameter (whether parent POMs should be included)
+             * @param includeParent whether parent POMs should be included
+             * @return {@link Builder} instance
+             */
+            public Builder withIncludeParent( boolean includeParent )
+            {
+                this.includeParent = includeParent;
+                return this;
+            }
+
+            /**
+             * Supplies the information whether to automatically infer associations
+             * @param autoLinkItems whether to automatically infer associations
+             * @return {@link Builder} instance
+             */
+            public Builder withAutoLinkItems( boolean autoLinkItems )
+            {
+                this.autoLinkItems = autoLinkItems;
+                return this;
+            }
+
+            /**
+             * Returns the {@link VersionPropertiesMapRequest} instance
+             * @return {@link VersionPropertiesMapRequest} instance
+             */
+            public VersionPropertiesMapRequest build()
+            {
+                VersionPropertiesMapRequest instance = new VersionPropertiesMapRequest();
+                instance.mavenProject = this.mavenProject;
+                instance.propertyDefinitions = propertyDefinitions;
+                instance.includeProperties = includeProperties;
+                instance.excludeProperties = excludeProperties;
+                instance.includeParent = includeParent == null || includeParent;
+                instance.autoLinkItems = autoLinkItems == null || autoLinkItems;
+                return instance;
+            }
+        }
+    }
 
     /**
      * Attempts to resolve the artifact.

--- a/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Unit tests for {@link DisplayPropertyUpdatesMojo}
@@ -84,5 +85,26 @@ public class DisplayPropertyUpdatesMojoTest extends AbstractMojoTestCase
 
         assertThat( String.join( "", Files.readAllLines( tempFile ) ),
                 matchesPattern( ".*\\$\\{ver} \\.* 1\\.0\\.0 -> 2\\.0\\.0.*" ) );
+    }
+
+    @Test
+    public void testDisablePropertiesFromParent() throws Exception
+    {
+        Path tempFile = Files.createTempFile( tempDir, "output", "" );
+
+        TestUtils.copyDir( Paths.get( "src/test/resources/org/codehaus/mojo/display-property-updates/issue-367" ),
+                tempDir );
+        DisplayPropertyUpdatesMojo mojo =
+                (DisplayPropertyUpdatesMojo) mojoRule.lookupConfiguredMojo( tempDir.resolve( "child" ).toFile(),
+                        "display-property-updates" );
+        mojo.outputEncoding = UTF_8;
+        mojo.outputFile = tempFile.toFile();
+        mojo.setPluginContext( new HashMap<>() );
+        mojo.artifactMetadataSource = MockUtils.mockArtifactMetadataSource();
+        mojo.includeParent = false;
+        mojo.execute();
+
+        assertThat( String.join( "", Files.readAllLines( tempFile ) ),
+                not( matchesPattern( ".*\\$\\{ver} \\.* 1\\.0\\.0 -> 2\\.0\\.0.*" ) ) );
     }
 }

--- a/src/test/java/org/codehaus/mojo/versions/PropertyUpdatesReportMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/PropertyUpdatesReportMojoTest.java
@@ -1,0 +1,98 @@
+package org.codehaus.mojo.versions;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.OutputStream;
+import java.util.Locale;
+
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.doxia.module.xhtml5.Xhtml5SinkFactory;
+import org.apache.maven.doxia.sink.SinkFactory;
+import org.apache.maven.doxia.tools.SiteTool;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.plugin.testing.stubs.StubArtifactRepository;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.codehaus.mojo.versions.utils.MockUtils.mockArtifactMetadataSource;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockSiteTool;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Unit tests for {@link PropertyUpdatesReportMojo}
+ */
+public class PropertyUpdatesReportMojoTest extends AbstractMojoTestCase
+{
+    @Rule
+    public MojoRule mojoRule = new MojoRule( this );
+    private static final ArtifactMetadataSource ARTIFACT_METADATA_SOURCE = mockArtifactMetadataSource();
+    private static final SiteTool SITE_TOOL = mockSiteTool();
+    private static final StubArtifactRepository LOCAL_REPOSITORY = new StubArtifactRepository( "" );
+
+    @Test
+    public void testIncludeParentTrueShouldContainProperty() throws Exception
+    {
+        OutputStream os = new ByteArrayOutputStream();
+        SinkFactory sinkFactory = new Xhtml5SinkFactory();
+
+        PropertyUpdatesReportMojo mojo =
+                (PropertyUpdatesReportMojo) mojoRule.lookupConfiguredMojo(
+                        new File( "src/test/resources/org/codehaus/mojo/display-property-updates/issue-367/child" ),
+                        "property-updates-report" );
+        setVariableValueToObject( mojo, "localRepository", LOCAL_REPOSITORY );
+        setVariableValueToObject( mojo, "siteTool", SITE_TOOL );
+        setVariableValueToObject( mojo, "artifactMetadataSource", ARTIFACT_METADATA_SOURCE );
+        setVariableValueToObject( mojo, "includeParent", true );
+        mojo.generate( sinkFactory.createSink( os ), sinkFactory, Locale.getDefault() );
+
+        String output = os.toString()
+                .replaceAll( "<[^>]+>", " " )
+                .replaceAll( "&[^;]+;", " " )
+                .replaceAll( "\\s+", " " );
+        assertThat( output, containsString( "${ver}" ) );
+    }
+
+    @Test
+    public void testIncludeParentFalseShouldNotCountainProperty() throws Exception
+    {
+        OutputStream os = new ByteArrayOutputStream();
+        SinkFactory sinkFactory = new Xhtml5SinkFactory();
+
+        PropertyUpdatesReportMojo mojo =
+                (PropertyUpdatesReportMojo) mojoRule.lookupConfiguredMojo(
+                        new File( "src/test/resources/org/codehaus/mojo/display-property-updates/issue-367/child" ),
+                        "property-updates-report" );
+        setVariableValueToObject( mojo, "localRepository", new StubArtifactRepository( "" ) );
+        setVariableValueToObject( mojo, "siteTool", SITE_TOOL );
+        setVariableValueToObject( mojo, "artifactMetadataSource", ARTIFACT_METADATA_SOURCE );
+        setVariableValueToObject( mojo, "includeParent", false );
+        mojo.generate( sinkFactory.createSink( os ), sinkFactory, Locale.getDefault() );
+
+        String output = os.toString()
+                .replaceAll( "<[^>]+>", " " )
+                .replaceAll( "&[^;]+;", " " )
+                .replaceAll( "\\s+", " " );
+        assertThat( output, not( containsString( "${ver}" ) ) );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
@@ -182,7 +182,14 @@ public class DefaultVersionsHelperTest extends AbstractMojoTestCase
         };
         // should not throw an IllegalStateException
         Map<Property, PropertyVersions> result =
-            helper.getVersionPropertiesMap( project, propertyDefinitions, "foo.version", "bar.version", false );
+            helper.getVersionPropertiesMap( VersionsHelper.VersionPropertiesMapRequest.builder()
+                    .withMavenProject( project )
+                    .withPropertyDefinitions( propertyDefinitions )
+                    .withIncludeProperties( "foo.version" )
+                    .withExcludeProperties( "bar.version" )
+                    .withIncludeParent( false )
+                    .withAutoLinkItems( false )
+                    .build() );
         assertTrue( result.isEmpty() );
     }
 


### PR DESCRIPTION
Introducing a new parameter: `includeParent`, default `true` so that it would be possible to disable consulting parent POMs when resolving properties. This might come especially handy in projects using large parents like e.g. one of Spring Boot.