### PR TITLE
#794: SetMojo would always change the version of the POM, regardless if a match was found

### DIFF
--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-794/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-794/pom.xml
@@ -1,0 +1,7 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+</project>


### PR DESCRIPTION
Probably an old technical debt of sorts in SetMojo: the mojo would normally change the files matching oldVersion, groupId, or ArtifactId.

However, if no match was found in the reactor, then the root model is changed anyway!

https://github.com/mojohaus/versions-maven-plugin/blob/b75a5656113f8974e7bb26f2cd0cdeacff59800e/src/main/java/org/codehaus/mojo/versions/SetMojo.java#L384

I don't understand the reason for it. When checked git blame, the original author added those lines to fix some breaking integration tests. However, it looks like no tests fail even with those lines removed.

Anyhow. I don't think that behaviour was intuitive and it is certainly very unexpected.

A side effect of that behaviour was that, with "always", the timestamp of the file was updated regardless if a match was found. So I had to explicitly add all reactor files if the update timestamp switch is set to "always".