### PR TITLE
Resolves #505: getReactorModels using correct module paths when the module name includes pom.xml

### DIFF
--- a/versions-maven-plugin/src/it/it-set-issue-505/invoker.properties
+++ b/versions-maven-plugin/src/it/it-set-issue-505/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:set
+invoker.mavenOpts = -DnewVersion=TEST

--- a/versions-maven-plugin/src/it/it-set-issue-505/moduleA/moduleB/pom.xml
+++ b/versions-maven-plugin/src/it/it-set-issue-505/moduleA/moduleB/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>moduleA</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>moduleB</artifactId>
+
+</project>

--- a/versions-maven-plugin/src/it/it-set-issue-505/moduleA/pom.xml
+++ b/versions-maven-plugin/src/it/it-set-issue-505/moduleA/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>default-artifact</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>moduleA</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>moduleB/pom.xml</module>
+    </modules>
+
+</project>

--- a/versions-maven-plugin/src/it/it-set-issue-505/pom.xml
+++ b/versions-maven-plugin/src/it/it-set-issue-505/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>moduleA/pom.xml</module>
+    </modules>
+
+</project>

--- a/versions-maven-plugin/src/it/it-set-issue-505/verify.groovy
+++ b/versions-maven-plugin/src/it/it-set-issue-505/verify.groovy
@@ -1,0 +1,3 @@
+assert new File( basedir, "pom.xml" ).text.contains( 'TEST' )
+assert new File( basedir, "moduleA/pom.xml" ).text.contains( 'TEST' )
+assert new File( basedir, "moduleA/moduleB/pom.xml" ).text.contains( 'TEST' )

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/api/PomHelperTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/api/PomHelperTest.java
@@ -7,34 +7,39 @@ import java.io.File;
 import java.io.StringReader;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.stax2.XMLInputFactory2;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.codehaus.mojo.versions.utils.ModifiedPomXMLEventReaderUtils.matches;
 import static org.codehaus.stax2.XMLInputFactory2.P_PRESERVE_LOCATION;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the methods of {@link PomHelper}.
  */
-public class PomHelperTest
+public class PomHelperTest extends AbstractMojoTestCase
 {
+    @Rule
+    public MojoRule mojoRule = new MojoRule( this );
+
     private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory2.newInstance();
 
     @BeforeClass
-    public static void setUp()
+    public static void setUpClass()
     {
         INPUT_FACTORY.setProperty( P_PRESERVE_LOCATION, Boolean.TRUE );
     }
@@ -264,5 +269,14 @@ public class PomHelperTest
                 "child", "value" ), is( true ) );
         assertThat( xmlEventReader,
                 matches( "<super-parent><parent><child>value</child></parent></super-parent>" ) );
+    }
+
+    @Test
+    public void testIssue505ChildModules() throws Exception
+    {
+        MavenProject project = mojoRule.readMavenProject(
+                new File( "src/test/resources/org/codehaus/mojo/versions/api/issue-505" ) );
+        Map<String, Model> reactorModels = PomHelper.getReactorModels( project, new SystemStreamLog() );
+        assertThat( reactorModels.keySet(), hasSize( 3 ) );
     }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/versions/api/issue-505/moduleA/moduleA.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/versions/api/issue-505/moduleA/moduleA.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>default-artifact</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>moduleA</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>moduleB/pom.xml</module>
+    </modules>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/versions/api/issue-505/moduleA/moduleB/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/versions/api/issue-505/moduleA/moduleB/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>moduleA</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>moduleB</artifactId>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/versions/api/issue-505/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/versions/api/issue-505/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>moduleA/moduleA.xml</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <goals>
+                    <goal>set</goal>
+                </goals>
+                <configuration>
+                    <newVersion>TEST</newVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Nothing fancy or spectacular, just a simple bug fix for the edge case of having the module name include the pom.xml file path. In the unpatched implementation, the "/pom.xml" was treated as part of the directory name when descending down the module tree to retrieve child models... Fixed that.

Added some tests (unit test for the PomHelper method + integration test for the use case from the issue).

@slawekjaranowski please review