### PR TITLE
Make includeParent false by default to retain backward compatibility.

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -131,11 +131,11 @@ public class DisplayPropertyUpdatesMojo
     private boolean allowIncrementalUpdates;
 
     /**
-     * <p>Whether to include property updates from parent.</p>
+     * <p>Whether to include property updates from parent. Default: {@code false}</p>
      *
      * @since 2.14.0
      */
-    @Parameter( property = "includeParent", defaultValue = "true" )
+    @Parameter( property = "includeParent", defaultValue = "false" )
     protected boolean includeParent = true;
 
     // -------------------------- STATIC METHODS --------------------------

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/PropertyUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/PropertyUpdatesReportMojo.java
@@ -92,11 +92,11 @@ public class PropertyUpdatesReportMojo extends AbstractVersionsReport<PropertyUp
     private boolean autoLinkItems;
 
     /**
-     * <p>Whether to include property updates from parent.</p>
+     * <p>Whether to include property updates from parent. Default: {@code false}</p>
      *
      * @since 2.14.0
      */
-    @Parameter( property = "includeParent", defaultValue = "true" )
+    @Parameter( property = "includeParent", defaultValue = "false" )
     private boolean includeParent = true;
 
     /**

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
@@ -81,6 +81,7 @@ public class DisplayPropertyUpdatesMojoTest extends AbstractMojoTestCase
         mojo.outputFile = tempFile.toFile();
         mojo.setPluginContext( new HashMap<>() );
         mojo.artifactMetadataSource = MockUtils.mockArtifactMetadataSource();
+        mojo.includeParent = true;
         mojo.execute();
 
         assertThat( String.join( "", Files.readAllLines( tempFile ) ),


### PR DESCRIPTION
There have been compelling remarks that includeParent should be false, otherwise we're breaking backwards compatibility. I agree. Hence this small PR.