### PR TITLE
Resolves #837: Add includeParent (default true) to UpdatePropertiesMojo

### DIFF
--- a/versions-maven-plugin/src/it/it-update-properties-issue-837/invoker.properties
+++ b/versions-maven-plugin/src/it/it-update-properties-issue-837/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:update-properties
+invoker.mavenOpts = -DincludeParent=false

--- a/versions-maven-plugin/src/it/it-update-properties-issue-837/parent-pom.xml
+++ b/versions-maven-plugin/src/it/it-update-properties-issue-837/parent-pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>parent-artifact</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <artifact-version>1.0</artifact-version>
+    </properties>
+
+</project>

--- a/versions-maven-plugin/src/it/it-update-properties-issue-837/pom.xml
+++ b/versions-maven-plugin/src/it/it-update-properties-issue-837/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>parent-artifact</artifactId>
+        <version>1.0.0</version>
+        <relativePath>parent-pom.xml</relativePath>
+    </parent>
+
+    <artifactId>child-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-api</artifactId>
+            <version>${artifact-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-update-properties-issue-837/verify.groovy
+++ b/versions-maven-plugin/src/it/it-update-properties-issue-837/verify.groovy
@@ -1,0 +1,1 @@
+assert ! ( new File( basedir, "build.log" ).text.contains( 'Property ${artifact-version}' ) )

--- a/versions-maven-plugin/src/it/it-update-property-issue-837/invoker.properties
+++ b/versions-maven-plugin/src/it/it-update-property-issue-837/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:update-property
+invoker.mavenOpts = -DincludeParent=false -Dproperty=artifact-version

--- a/versions-maven-plugin/src/it/it-update-property-issue-837/parent-pom.xml
+++ b/versions-maven-plugin/src/it/it-update-property-issue-837/parent-pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>parent-artifact</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <artifact-version>1.0</artifact-version>
+    </properties>
+
+</project>

--- a/versions-maven-plugin/src/it/it-update-property-issue-837/pom.xml
+++ b/versions-maven-plugin/src/it/it-update-property-issue-837/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>parent-artifact</artifactId>
+        <version>1.0.0</version>
+        <relativePath>parent-pom.xml</relativePath>
+    </parent>
+
+    <artifactId>child-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-api</artifactId>
+            <version>${artifact-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-update-property-issue-837/verify.groovy
+++ b/versions-maven-plugin/src/it/it-update-property-issue-837/verify.groovy
@@ -1,0 +1,2 @@
+assert ! ( new File( basedir, "build.log" ).text
+        .contains( 'Property ${artifact-version}: Set of valid available versions is [1.0, 1.0.1,' ) )

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -495,6 +495,20 @@ public abstract class AbstractVersionsUpdaterMojo
         return true;
     }
 
+    /**
+     * Attempts to update the property to a newer version, if that exists
+     * @param pom               pom to update
+     * @param property          property to update
+     * @param version           {@link PropertyVersions} object
+     * @param currentVersion    current version
+     * @param allowDowngrade    if downgrades should be allowed if snapshots are not allowed
+     * @param unchangedSegment  most major segment not to be changed
+     * @return new version of the artifact, if the property was updated; {@code null} if there was no update
+     * @throws XMLStreamException thrown from {@link ModifiedPomXMLEventReader} if the update doesn't succeed
+     * @throws InvalidVersionSpecificationException thrown if {@code unchangedSegment} doesn't match the version
+     * @throws InvalidSegmentException thrown if {@code unchangedSegment} is invalid
+     * @throws MojoExecutionException thrown if any other error occurs
+     */
     protected ArtifactVersion updatePropertyToNewestVersion( ModifiedPomXMLEventReader pom, Property property,
                                                              PropertyVersions version, String currentVersion,
                                                              boolean allowDowngrade,
@@ -513,9 +527,10 @@ public abstract class AbstractVersionsUpdaterMojo
         else if ( PomHelper.setPropertyVersion( pom, version.getProfileId(), property.getName(), winner.toString() ) )
         {
             getLog().info( "Updated ${" + property.getName() + "} from " + currentVersion + " to " + winner );
+            return winner;
         }
 
-        return winner;
+        return null;
     }
 
     /**

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
@@ -19,32 +19,20 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
-import javax.inject.Inject;
-import javax.xml.stream.XMLStreamException;
-
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.maven.artifact.versioning.ArtifactVersion;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.wagon.Wagon;
-import org.codehaus.mojo.versions.api.ArtifactAssociation;
 import org.codehaus.mojo.versions.api.Property;
-import org.codehaus.mojo.versions.api.PropertyVersions;
-import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.api.VersionsHelper;
-import org.codehaus.mojo.versions.api.recording.ChangeRecord;
 import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
-import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
-import org.codehaus.mojo.versions.recording.DefaultChangeRecord;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
-import static org.codehaus.mojo.versions.utils.SegmentUtils.determineUnchangedSegment;
+import javax.inject.Inject;
+import javax.xml.stream.XMLStreamException;
+import java.util.Map;
 
 /**
  * Sets properties to the latest versions of specific artifacts.
@@ -53,11 +41,8 @@ import static org.codehaus.mojo.versions.utils.SegmentUtils.determineUnchangedSe
  * @since 1.0-alpha-1
  */
 @Mojo( name = "update-properties", threadSafe = true )
-public class UpdatePropertiesMojo extends AbstractVersionsDependencyUpdaterMojo
+public class UpdatePropertiesMojo extends UpdatePropertiesMojoBase
 {
-
-    // ------------------------------ FIELDS ------------------------------
-
     /**
      * Any restrictions that apply to specific properties.
      *
@@ -82,61 +67,6 @@ public class UpdatePropertiesMojo extends AbstractVersionsDependencyUpdaterMojo
     @Parameter( property = "excludeProperties" )
     private String excludeProperties = null;
 
-    /**
-     * Whether properties linking versions should be auto-detected or not.
-     *
-     * @since 1.0-alpha-2
-     */
-    @Parameter( property = "autoLinkItems",
-                defaultValue = "true" )
-    private boolean autoLinkItems;
-
-    /**
-     * If a property points to a version like <code>1.2.3-SNAPSHOT</code> and your repo contains a version like
-     * <code>1.1.0</code> without settings this to <code>true</code> the property will not being changed.
-     *
-     * @since 2.4
-     */
-    @Parameter( property = "allowDowngrade",
-                defaultValue = "false" )
-    private boolean allowDowngrade;
-
-    /**
-     * Whether to allow the major version number to be changed.
-     *
-     * @since 2.4
-     */
-    @Parameter( property = "allowMajorUpdates",
-                defaultValue = "true" )
-    protected boolean allowMajorUpdates = true;
-
-    /**
-     * <p>Whether to allow the minor version number to be changed.</p>
-     *
-     * <p><b>Note: {@code false} also implies {@linkplain #allowMajorUpdates} {@code false}</b></p>
-     *
-     * @since 2.4
-     */
-    @Parameter( property = "allowMinorUpdates",
-                defaultValue = "true" )
-    protected boolean allowMinorUpdates = true;
-
-    /**
-     * <p>Whether to allow the incremental version number to be changed.</p>
-     *
-     * <p><b>Note: {@code false} also implies {@linkplain #allowMajorUpdates}
-     * and {@linkplain #allowMinorUpdates} {@code false}</b></p>
-     *
-     * @since 2.4
-     */
-    @Parameter( property = "allowIncrementalUpdates",
-                defaultValue = "true" )
-    protected boolean allowIncrementalUpdates = true;
-
-    // -------------------------- STATIC METHODS --------------------------
-
-    // -------------------------- OTHER METHODS --------------------------
-
     @Inject
     public UpdatePropertiesMojo( RepositorySystem repositorySystem,
                                  org.eclipse.aether.RepositorySystem aetherRepositorySystem,
@@ -157,74 +87,15 @@ public class UpdatePropertiesMojo extends AbstractVersionsDependencyUpdaterMojo
     protected void update( ModifiedPomXMLEventReader pom )
             throws MojoExecutionException, MojoFailureException, XMLStreamException
     {
-        Map<Property, PropertyVersions> propertyVersions = getHelper().getVersionPropertiesMap(
+        update( pom, getHelper().getVersionPropertiesMap(
                 VersionsHelper.VersionPropertiesMapRequest.builder()
                         .withMavenProject( getProject() )
                         .withPropertyDefinitions( properties )
                         .withIncludeProperties( includeProperties )
                         .withExcludeProperties( excludeProperties )
                         .withAutoLinkItems( autoLinkItems )
-                        .build() );
-        for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
-        {
-            Property property = entry.getKey();
-            PropertyVersions version = entry.getValue();
-
-            final String currentVersion = getProject().getProperties().getProperty( property.getName() );
-            if ( currentVersion == null )
-            {
-                continue;
-            }
-            boolean canUpdateProperty = true;
-            for ( ArtifactAssociation association : version.getAssociations() )
-            {
-                if ( !( isIncluded( association.getArtifact() ) ) )
-                {
-                    getLog().info(
-                        "Not updating the property ${" + property.getName() + "} because it is used by artifact "
-                            + association.getArtifact().toString()
-                            + " and that artifact is not included in the list of "
-                            + " allowed artifacts to be updated." );
-                    canUpdateProperty = false;
-                    break;
-                }
-            }
-
-            if ( canUpdateProperty )
-            {
-                Optional<Segment> unchangedSegment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
-                                                         allowIncrementalUpdates, getLog() );
-                try
-                {
-                    ArtifactVersion targetVersion =
-                            updatePropertyToNewestVersion( pom, property, version, currentVersion,
-                                    allowDowngrade, unchangedSegment );
-
-                    if ( targetVersion != null )
-                    {
-                        for ( final ArtifactAssociation association : version.getAssociations() )
-                        {
-                            if ( ( isIncluded( association.getArtifact() ) ) )
-                            {
-                                getChangeRecorder().recordChange( DefaultChangeRecord.builder()
-                                                                      .withKind(
-                                                                          ChangeRecord.ChangeKind.PROPERTY )
-                                                                      .withArtifact( association.getArtifact() )
-                                                                      .withOldVersion( currentVersion )
-                                                                      .withNewVersion( targetVersion.toString() )
-                                                                      .build() );
-                            }
-                        }
-                    }
-                }
-                catch ( InvalidSegmentException | InvalidVersionSpecificationException e )
-                {
-                    getLog().warn( String.format( "Skipping the processing of %s:%s due to: %s", property.getName(),
-                            property.getVersion(), e.getMessage() ) );
-                }
-            }
-
-        }
+                        .withIncludeParent( includeParent )
+                        .build() ) );
     }
 
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojoBase.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojoBase.java
@@ -1,0 +1,179 @@
+package org.codehaus.mojo.versions;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.repository.RepositorySystem;
+import org.apache.maven.wagon.Wagon;
+import org.codehaus.mojo.versions.api.ArtifactAssociation;
+import org.codehaus.mojo.versions.api.Property;
+import org.codehaus.mojo.versions.api.PropertyVersions;
+import org.codehaus.mojo.versions.api.Segment;
+import org.codehaus.mojo.versions.api.recording.ChangeRecord;
+import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
+import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
+import org.codehaus.mojo.versions.recording.DefaultChangeRecord;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.codehaus.mojo.versions.utils.SegmentUtils.determineUnchangedSegment;
+
+/**
+ * Common base class for {@link UpdatePropertiesMojo}
+ * and {@link UpdatePropertyMojo}
+ */
+public abstract class UpdatePropertiesMojoBase extends AbstractVersionsDependencyUpdaterMojo
+{
+    /**
+     * Whether properties linking versions should be auto-detected or not.
+     *
+     * @since 1.0-alpha-2
+     */
+    @Parameter( property = "autoLinkItems", defaultValue = "true" )
+    protected boolean autoLinkItems;
+
+    /**
+     * If a property points to a version like <code>1.2.3</code> and your repository contains versions like
+     * <code>1.2.3</code> and <code>1.1.0</code> without settings this to <code>true</code> the property will never
+     * being changed back to <code>1.1.0</code> by using <code>-DnewVersion=[1.1.0]</code>.
+     *
+     * @since 3.0.0
+     */
+    @Parameter( property = "allowDowngrade", defaultValue = "false" )
+    protected boolean allowDowngrade;
+
+    /**
+     * Whether to allow the major version number to be changed.
+     *
+     * @since 2.4
+     */
+    @Parameter( property = "allowMajorUpdates", defaultValue = "true" )
+    protected boolean allowMajorUpdates;
+
+    /**
+     * <p>Whether to allow the minor version number to be changed.</p>
+     *
+     * <p><b>Note: {@code false} also implies {@linkplain #allowMajorUpdates} {@code false}</b></p>
+     *
+     * @since 2.4
+     */
+    @Parameter( property = "allowMinorUpdates", defaultValue = "true" )
+    protected boolean allowMinorUpdates;
+
+    /**
+     * <p>Whether to allow the incremental version number to be changed.</p>
+     *
+     * <p><b>Note: {@code false} also implies {@linkplain #allowMajorUpdates}
+     * and {@linkplain #allowMinorUpdates} {@code false}</b></p>
+     *
+     * @since 2.4
+     */
+    @Parameter( property = "allowIncrementalUpdates", defaultValue = "true" )
+    protected boolean allowIncrementalUpdates;
+
+    /**
+     * <p>Whether to include parent POMs in the search. Default: {@code true}</p>
+     * <p>Setting this to {@code false} can speed up execution, but will not resolve
+     * property-bound dependencies, defined in parent POMs.
+     *
+     * @since 2.14.0
+     */
+
+    @Parameter( property = "includeParent", defaultValue = "true" )
+    protected boolean includeParent = true;
+
+    public UpdatePropertiesMojoBase( RepositorySystem repositorySystem,
+                                 org.eclipse.aether.RepositorySystem aetherRepositorySystem,
+                                 Map<String, Wagon> wagonMap,
+                                 Map<String, ChangeRecorder> changeRecorders )
+    {
+        super( repositorySystem, aetherRepositorySystem, wagonMap, changeRecorders );
+    }
+
+    protected void update( ModifiedPomXMLEventReader pom, Map<Property, PropertyVersions> propertyVersions )
+            throws XMLStreamException
+    {
+        for ( Map.Entry<Property, PropertyVersions> entry : propertyVersions.entrySet() )
+        {
+            Property property = entry.getKey();
+            PropertyVersions version = entry.getValue();
+
+            final String currentVersion = getProject().getProperties().getProperty( property.getName() );
+            if ( currentVersion == null )
+            {
+                continue;
+            }
+            boolean canUpdateProperty = true;
+            for ( ArtifactAssociation association : version.getAssociations() )
+            {
+                if ( !( isIncluded( association.getArtifact() ) ) )
+                {
+                    getLog().info(
+                            "Not updating the property ${" + property.getName() + "} because it is used by artifact "
+                                    + association.getArtifact().toString()
+                                    + " and that artifact is not included in the list of "
+                                    + " allowed artifacts to be updated." );
+                    canUpdateProperty = false;
+                    break;
+                }
+            }
+
+            if ( canUpdateProperty )
+            {
+                Optional<Segment> unchangedSegment = determineUnchangedSegment( allowMajorUpdates, allowMinorUpdates,
+                        allowIncrementalUpdates, getLog() );
+                try
+                {
+                    ArtifactVersion targetVersion =
+                            updatePropertyToNewestVersion( pom, property, version, currentVersion,
+                                    allowDowngrade, unchangedSegment );
+
+                    if ( targetVersion != null )
+                    {
+                        for ( final ArtifactAssociation association : version.getAssociations() )
+                        {
+                            if ( ( isIncluded( association.getArtifact() ) ) )
+                            {
+                                getChangeRecorder().recordChange( DefaultChangeRecord.builder()
+                                        .withKind(
+                                                ChangeRecord.ChangeKind.PROPERTY )
+                                        .withArtifact( association.getArtifact() )
+                                        .withOldVersion( currentVersion )
+                                        .withNewVersion( targetVersion.toString() )
+                                        .build() );
+                            }
+                        }
+                    }
+                }
+                catch ( InvalidSegmentException | InvalidVersionSpecificationException | MojoExecutionException e )
+                {
+                    getLog().warn( String.format( "Skipping the processing of %s:%s due to: %s", property.getName(),
+                            property.getVersion(), e.getMessage() ) );
+                }
+            }
+
+        }
+    }
+}

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/issue-837/parent-pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/issue-837/parent-pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>parent-artifact</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <artifact-version>1.0</artifact-version>
+    </properties>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/issue-837/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/issue-837/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>parent-artifact</artifactId>
+        <version>1.0.0</version>
+        <relativePath>parent-pom.xml</relativePath>
+    </parent>
+
+    <artifactId>child-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>default-group</groupId>
+            <artifactId>default-artifact</artifactId>
+            <version>${artifact-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
Upon request of a user in #793, adding `includeParent` (`true` by default) to `UpdatePropertiesMojo`.

Setting it to `false` will speed up execution to a great extend without sacrificing accuracy in most cases. However, if the POM redefines properties used in parent POMs, dependencies bound to those properties will not be discovered, so the plugin will not redefine those properties. Therefore the default value is `true`.