### PR TITLE
Wagon should use remote repository instead of proxy repository for repo authentication

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -833,7 +833,7 @@ public class DefaultVersionsHelper
                     .map( authentication -> new AuthenticationInfo()
                         {{
                             try ( AuthenticationContext authCtx = AuthenticationContext
-                                    .forProxy( mavenSession.getRepositorySession(), repository ) )
+                                    .forRepository( mavenSession.getRepositorySession(), repository ) )
                             {
                                 ofNullable( authCtx.get( AuthenticationContext.USERNAME ) )
                                         .ifPresent( this::setUserName );


### PR DESCRIPTION
Quick fix, fixing a typo. No unit tests since it would require lots of mocking, and it was not possible to inject the RemoteRepositorySession object. And a WireMock test would be too much of an overkill for this IMO.